### PR TITLE
Add github actions CI for linux and macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
         run: |
           make all
         env:
-          CC: gcc
-          CXX: g++
+          CC: clang
+          CXX: clang++
       - name: assemble examples
         run: |
           make examples
@@ -36,8 +36,8 @@ jobs:
         run: |
           make all
         env:
-          CC: gcc
-          CXX: g++
+          CC: clang
+          CXX: clang++
       - name: assemble examples
         run: |
           make examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build-linux-gcc:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: build toolchain
+        run: |
+          make all
+        env:
+          CC: gcc
+          CXX: g++
+      - name: assemble examples
+        run: |
+          make examples
+  build-linux-clang:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: build toolchain
+        run: |
+          make all
+        env:
+          CC: gcc
+          CXX: g++
+      - name: assemble examples
+        run: |
+          make examples
+  build-macos:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: build toolchain
+        run: |
+          make all
+        env:
+          CC: gcc
+          CXX: g++
+      - name: assemble examples
+        run: |
+          make examples
+# TODO: there is no CI build for windows or FreeBSD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,5 @@ jobs:
       - name: assemble examples
         run: |
           make examples
-# TODO: there is no CI build for windows or FreeBSD
+# TODO(#20): there is no CI build for windows 
+# TODO: there is no CI build for FreeBSD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
         run: |
           make examples
 # TODO(#20): there is no CI build for windows 
-# TODO: there is no CI build for FreeBSD
+# TODO(#21): there is no CI build for FreeBSD


### PR DESCRIPTION
just copied from ebisp. also builds the examples, but does not run them (since some of them might need limits, eg. `fib`)