### PR TITLE
Implement pi example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CFLAGS=-Wall -Wextra -Wswitch-enum -Wmissing-prototypes -pedantic -std=c11
 LIBS=
 
-EXAMPLES=./examples/fib.bm ./examples/123i.bm ./examples/123f.bm ./examples/e.bm
+EXAMPLES=./examples/fib.bm ./examples/123i.bm ./examples/123f.bm ./examples/e.bm ./examples/pi.bm
 
 .PHONY: all
 all: basm bme debasm

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ $ make
 $ make examples
 $ ./bme -i ./examples/fib.bm -l 69
 $ ./bme -i ./examples/e.bm
+$ ./bme -i ./examples/pi.bm
 ```
 
 ## Components

--- a/examples/pi.basm
+++ b/examples/pi.basm
@@ -1,0 +1,57 @@
+#
+# π = (4/1) - (4/3) + (4/5) - (4/7) + (4/9) - (4/11) + (4/13) - (4/15) ...
+# Take 4 and subtract 4 divided by 3. Then add 4 divided by 5.
+# Then subtract 4 divided by 7. Continue alternating between adding
+# and subtracting fractions with a numerator of 4 and a denominator of each
+# subsequent odd number. The more times you do this, the closer you will get to pi.
+#
+
+push 4.0        # acc (result of first division 4/1)
+push 3.0        # denominator
+push 750000     # counter
+
+loop:
+    swap 2      # swap counter (top of stack) with current acc
+
+    # calculate next denominator
+
+    push 4.0
+    dup 2
+    push 2.0
+    plusf
+    swap 3
+
+    # calculate with current denominator
+
+    divf        #        (4/n)
+    minusf      # acc - ^
+
+    # calculate next denominator
+
+    push 4.0
+    dup 2
+    push 2.0
+    plusf
+    swap 3
+
+    # calculate with current denominator
+
+    divf        #        (4/n)
+    plusf       # acc + ^
+
+    # decrement counter
+    swap 2
+    push 1
+    minusi
+
+    dup 0       # duplicate current counter since jmp_if consumes top of stack
+    jmp_if loop
+
+# clean the stack and only have pi left
+
+multi           # top of stack is 0 so this operation will result in 0
+                # and get rids of the `denominator` on the stack
+minusi          # subtract 0 so that the last item on the stack
+                # will be `acc`, which is pi
+
+halt

--- a/src/bm.h
+++ b/src/bm.h
@@ -716,6 +716,18 @@ void bm_translate_source(String_View source, Bm *bm, Basm *basm)
                     bm->program[bm->program_size++] = (Inst) {
                         .type = INST_PLUSI
                     };
+                } else if (sv_eq(token, cstr_as_sv(inst_name(INST_MINUSI)))) {
+                    bm->program[bm->program_size++] = (Inst) {
+                        .type = INST_MINUSI
+                    };
+                } else if (sv_eq(token, cstr_as_sv(inst_name(INST_DIVI)))) {
+                    bm->program[bm->program_size++] = (Inst) {
+                        .type = INST_DIVI
+                    };
+                } else if (sv_eq(token, cstr_as_sv(inst_name(INST_MULTI)))) {
+                    bm->program[bm->program_size++] = (Inst) {
+                        .type = INST_MULTI
+                    };
                 } else if (sv_eq(token, cstr_as_sv(inst_name(INST_JMP)))) {
                     if (operand.count > 0 && isdigit(*operand.data)) {
                         bm->program[bm->program_size++] = (Inst) {
@@ -751,6 +763,10 @@ void bm_translate_source(String_View source, Bm *bm, Basm *basm)
                 } else if (sv_eq(token, cstr_as_sv(inst_name(INST_PLUSF)))) {
                     bm->program[bm->program_size++] = (Inst) {
                         .type = INST_PLUSF
+                    };
+                } else if (sv_eq(token, cstr_as_sv(inst_name(INST_MINUSF)))) {
+                    bm->program[bm->program_size++] = (Inst) {
+                        .type = INST_MINUSF
                     };
                 } else if (sv_eq(token, cstr_as_sv(inst_name(INST_DIVF)))) {
                     bm->program[bm->program_size++] = (Inst) {


### PR DESCRIPTION
Had some fun implementing a (slow approximation of) pi example in basm. In the course of doing that I ran into some missing instructions in the source translation function. 

The pi example makes use of a loop based on a counter to stop calculation.
The result after running it is:
```
$ ./bme -i examples/pi.bm
Stack:
  u64: 4614256658053244912, i64: 4614256658053244912, f64: 3.141593, ptr: 0x400921fbadbea7f0
```