### PR TITLE
(#20) Add MSVC build for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,15 @@ jobs:
       - name: assemble examples
         run: |
           make examples
-# TODO(#20): there is no CI build for windows 
+  build-windows-msvc:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v1
+        # this runs vcvarsall for us, so we get the MSVC toolchain in PATH.
+      - uses: seanmiddleditch/gha-setup-vsdevenv@master
+      - name: build all and examples
+        shell: cmd
+        # this replaces default PowerShell, which can't fail the build
+        run: |
+          ./build_msvc.bat examples
 # TODO(#21): there is no CI build for FreeBSD

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 bme
 basm
 debasm
+*.exe
+*.ilk
+*.obj
+*.pdb

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -1,0 +1,19 @@
+@echo off
+rem launch this from msvc-enabled console
+
+
+set CFLAGS=/std:c11 /O2 /FC /W4 /WX /wd4996 /nologo
+set LIBS=
+
+set EXAMPLES=./examples/fib.bm ./examples/123i.bm ./examples/123f.bm ./examples/e.bm
+
+cl.exe %CFLAGS% ./src/basm.c
+
+cl.exe %CFLAGS% ./src/bme.c
+
+cl.exe %CFLAGS% ./src/debasm.c
+
+if "%1" == "examples" setlocal EnableDelayedExpansion && for %%e in (%EXAMPLES%) do (
+    set name=%%e
+    "./basm.exe" !name:~0,-2!basm %%e
+)

--- a/src/bm.h
+++ b/src/bm.h
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <errno.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #define ARRAY_SIZE(xs) (sizeof(xs) / sizeof((xs)[0]))
 #define BM_STACK_CAPACITY 1024
@@ -403,7 +404,7 @@ Err bm_execute_inst(Bm *bm)
         if (bm->stack_size < 1) {
             return ERR_STACK_UNDERFLOW;
         }
-        fprintf(stdout, "  u64: %llu, i64: %lld, f64: %lf, ptr: %p\n",
+        fprintf(stdout, "  u64: %" PRIu64 ", i64: %" PRId64 ", f64: %lf, ptr: %p\n",
                 bm->stack[bm->stack_size - 1].as_u64,
                 bm->stack[bm->stack_size - 1].as_i64,
                 bm->stack[bm->stack_size - 1].as_f64,
@@ -463,7 +464,7 @@ void bm_dump_stack(FILE *stream, const Bm *bm)
     fprintf(stream, "Stack:\n");
     if (bm->stack_size > 0) {
         for (Inst_Addr i = 0; i < bm->stack_size; ++i) {
-            fprintf(stream, "  u64: %llu, i64: %lld, f64: %lf, ptr: %p\n",
+            fprintf(stream, "  u64: %" PRIu64 ", i64: %" PRId64 ", f64: %lf, ptr: %p\n",
                     bm->stack[i].as_u64,
                     bm->stack[i].as_i64,
                     bm->stack[i].as_f64,

--- a/src/bm.h
+++ b/src/bm.h
@@ -15,6 +15,7 @@
 #define BM_PROGRAM_CAPACITY 1024
 #define LABEL_CAPACITY 1024
 #define DEFERRED_OPERANDS_CAPACITY 1024
+#define NUMBER_LITERAL_CAPACITY 1024
 
 typedef enum {
     ERR_OK = 0,
@@ -657,8 +658,8 @@ void basm_push_deferred_operand(Basm *basm, Inst_Addr addr, String_View label)
 
 Word number_literal_as_word(String_View sv)
 {
-    assert(sv.count < 1024);
-    char cstr[1024];
+    assert(sv.count < NUMBER_LITERAL_CAPACITY);
+    char cstr[NUMBER_LITERAL_CAPACITY + 1];
     char *endptr = 0;
 
     memcpy(cstr, sv.data, sv.count);

--- a/src/bm.h
+++ b/src/bm.h
@@ -157,6 +157,7 @@ int inst_has_operand(Inst_Type type)
     case INST_GEF:         return 0;
     case NUMBER_OF_INSTS:
     default: assert(0 && "inst_has_operand: unreachable");
+        exit(1);
     }
 }
 
@@ -184,6 +185,7 @@ const char *inst_name(Inst_Type type)
     case INST_GEF:         return "gef";
     case NUMBER_OF_INSTS:
     default: assert(0 && "inst_name: unreachable");
+        exit(1);
     }
 }
 
@@ -206,6 +208,7 @@ const char *err_as_cstr(Err err)
         return "ERR_DIV_BY_ZERO";
     default:
         assert(0 && "err_as_cstr: Unreachable");
+        exit(1);
     }
 }
 
@@ -233,6 +236,7 @@ const char *inst_type_as_cstr(Inst_Type type)
     case INST_GEF:         return "INST_GEF";
     case NUMBER_OF_INSTS:
     default: assert(0 && "inst_type_as_cstr: unreachable");
+        exit(1);
     }
 }
 
@@ -399,7 +403,7 @@ Err bm_execute_inst(Bm *bm)
         if (bm->stack_size < 1) {
             return ERR_STACK_UNDERFLOW;
         }
-        fprintf(stdout, "  u64: %lu, i64: %ld, f64: %lf, ptr: %p\n",
+        fprintf(stdout, "  u64: %llu, i64: %lld, f64: %lf, ptr: %p\n",
                 bm->stack[bm->stack_size - 1].as_u64,
                 bm->stack[bm->stack_size - 1].as_i64,
                 bm->stack[bm->stack_size - 1].as_f64,
@@ -459,7 +463,7 @@ void bm_dump_stack(FILE *stream, const Bm *bm)
     fprintf(stream, "Stack:\n");
     if (bm->stack_size > 0) {
         for (Inst_Addr i = 0; i < bm->stack_size; ++i) {
-            fprintf(stream, "  u64: %lu, i64: %ld, f64: %lf, ptr: %p\n",
+            fprintf(stream, "  u64: %llu, i64: %lld, f64: %lf, ptr: %p\n",
                     bm->stack[i].as_u64,
                     bm->stack[i].as_i64,
                     bm->stack[i].as_f64,
@@ -653,7 +657,7 @@ void basm_push_deferred_operand(Basm *basm, Inst_Addr addr, String_View label)
 Word number_literal_as_word(String_View sv)
 {
     assert(sv.count < 1024);
-    char cstr[sv.count + 1];
+    char cstr[1024];
     char *endptr = 0;
 
     memcpy(cstr, sv.data, sv.count);

--- a/src/debasm.c
+++ b/src/debasm.c
@@ -1,5 +1,6 @@
 #define BM_IMPLEMENTATION
 #include "./bm.h"
+#include <inttypes.h>
 
 Bm bm = {0};
 
@@ -18,7 +19,7 @@ int main(int argc, char *argv[])
     for (Inst_Addr i = 0; i < bm.program_size; ++i) {
         printf("%s", inst_name(bm.program[i].type));
         if (inst_has_operand(bm.program[i].type)) {
-            printf(" %lld", bm.program[i].operand.as_i64);
+            printf(" %" PRIu64, bm.program[i].operand.as_i64);
         }
         printf("\n");
     }

--- a/src/debasm.c
+++ b/src/debasm.c
@@ -18,7 +18,7 @@ int main(int argc, char *argv[])
     for (Inst_Addr i = 0; i < bm.program_size; ++i) {
         printf("%s", inst_name(bm.program[i].type));
         if (inst_has_operand(bm.program[i].type)) {
-            printf(" %ld", bm.program[i].operand.as_i64);
+            printf(" %lld", bm.program[i].operand.as_i64);
         }
         printf("\n");
     }


### PR DESCRIPTION
Close #20 

Fixed MSVC errors:
* Not all switch cases return a value
* Same as in #16 (Differing definitions of `int64_t`)
* Expected constant expression for `char cstr[sv.count + 1];`