### PR TITLE
Introduce make targets 'clean' and 'clean-examples'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,10 @@ examples: $(EXAMPLES)
 %.bm: %.basm basm
 	./basm $< $@
 
+.PHONY: clean
+clean:
+	rm -fr basm bme debasm
 
+.PHONY: clean-examples
+clean-examples:
+	rm -f examples/*.bm


### PR DESCRIPTION
This PR supports the removal of generated executables (`clean`) and .bm example files (`clean-examples`).

Of course, both tasks could be combined into a single one.
However I find myself removing one or the other set of files more often than both together.

Your call.
