### PR TITLE
(#12) Add line number to source translating error

### DIFF
--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -5,7 +5,10 @@ rem launch this from msvc-enabled console
 set CFLAGS=/std:c11 /O2 /FC /W4 /WX /wd4996 /nologo
 set LIBS=
 
-set EXAMPLES=./examples/fib.bm ./examples/123i.bm ./examples/123f.bm ./examples/e.bm
+for /f "delims=" %%i in ('findstr "EXAMPLES=" "Makefile"') do (
+    set result=%%i
+)
+set EXAMPLES=%result:~9%
 
 cl.exe %CFLAGS% ./src/basm.c
 

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -5,18 +5,13 @@ rem launch this from msvc-enabled console
 set CFLAGS=/std:c11 /O2 /FC /W4 /WX /wd4996 /nologo
 set LIBS=
 
-for /f "delims=" %%i in ('findstr "EXAMPLES=" "Makefile"') do (
-    set result=%%i
-)
-set EXAMPLES=%result:~9%
-
 cl.exe %CFLAGS% ./src/basm.c
 
 cl.exe %CFLAGS% ./src/bme.c
 
 cl.exe %CFLAGS% ./src/debasm.c
 
-if "%1" == "examples" setlocal EnableDelayedExpansion && for %%e in (%EXAMPLES%) do (
+if "%1" == "examples" setlocal EnableDelayedExpansion && for /F "tokens=*" %%e in ('dir /b .\examples\*.basm') do (
     set name=%%e
-    "./basm.exe" !name:~0,-2!basm %%e
+    "./basm.exe" .\examples\%%e .\examples\!name:~0,-4!bm
 )

--- a/src/basm.c
+++ b/src/basm.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
 
     String_View source = sv_slurp_file(input_file_path);
 
-    bm_translate_source(source, &bm, &basm);
+    bm_translate_source(source, &bm, &basm, input_file_path);
     bm_save_program_to_file(&bm, output_file_path);
 
     return 0;

--- a/src/bm.h
+++ b/src/bm.h
@@ -128,7 +128,7 @@ Inst_Addr basm_find_label_addr(const Basm *basm, String_View name);
 void basm_push_label(Basm *basm, String_View name, Inst_Addr addr);
 void basm_push_deferred_operand(Basm *basm, Inst_Addr addr, String_View label);
 
-void bm_translate_source(String_View source, Bm *bm, Basm *basm);
+void bm_translate_source(String_View source, Bm *bm, Basm *basm, const char *input_file_path);
 
 Word number_literal_as_word(String_View sv);
 
@@ -691,7 +691,7 @@ Word number_literal_as_word(String_View sv)
     return result;
 }
 
-void bm_translate_source(String_View source, Bm *bm, Basm *basm)
+void bm_translate_source(String_View source, Bm *bm, Basm *basm, const char *input_file_path)
 {
     bm->program_size = 0;
     int line_number = 0;
@@ -822,8 +822,8 @@ void bm_translate_source(String_View source, Bm *bm, Basm *basm)
                         .type = INST_PRINT_DEBUG,
                     };
                 } else {
-                    fprintf(stderr, "ERROR: unknown instruction `%.*s` on line %d\n",
-                            (int) token.count, token.data, line_number);
+                    fprintf(stderr, "%s:%d: ERROR: unknown instruction `%.*s`\n",
+                            input_file_path, line_number, (int) token.count, token.data);
                     exit(1);
                 }
             }

--- a/src/bm.h
+++ b/src/bm.h
@@ -650,6 +650,7 @@ Inst_Addr basm_find_label_addr(const Basm *basm, String_View name)
         }
     }
 
+    // TODO(#43): unknown label basm error does not print its location
     fprintf(stderr, "ERROR: label `%.*s` does not exist\n",
             (int) name.count, name.data);
     exit(1);
@@ -683,6 +684,7 @@ Word number_literal_as_word(String_View sv)
     if ((size_t) (endptr - cstr) != sv.count) {
         result.as_f64 = strtod(cstr, &endptr);
         if ((size_t) (endptr - cstr) != sv.count) {
+            // TODO: invalid literal basm error does not print its location
             fprintf(stderr, "ERROR: `%s` is not a number literal\n", cstr);
             exit(1);
         }

--- a/src/bm.h
+++ b/src/bm.h
@@ -684,7 +684,7 @@ Word number_literal_as_word(String_View sv)
     if ((size_t) (endptr - cstr) != sv.count) {
         result.as_f64 = strtod(cstr, &endptr);
         if ((size_t) (endptr - cstr) != sv.count) {
-            // TODO: invalid literal basm error does not print its location
+            // TODO(#44): invalid literal basm error does not print its location
             fprintf(stderr, "ERROR: `%s` is not a number literal\n", cstr);
             exit(1);
         }

--- a/src/bm.h
+++ b/src/bm.h
@@ -694,11 +694,13 @@ Word number_literal_as_word(String_View sv)
 void bm_translate_source(String_View source, Bm *bm, Basm *basm)
 {
     bm->program_size = 0;
+    int line_number = 0;
 
     // First pass
     while (source.count > 0) {
         assert(bm->program_size < BM_PROGRAM_CAPACITY);
         String_View line = sv_trim(sv_chop_by_delim(&source, '\n'));
+        line_number += 1;
         if (line.count > 0 && *line.data != '#') {
             String_View token = sv_chop_by_delim(&line, ' ');
 
@@ -820,8 +822,8 @@ void bm_translate_source(String_View source, Bm *bm, Basm *basm)
                         .type = INST_PRINT_DEBUG,
                     };
                 } else {
-                    fprintf(stderr, "ERROR: unknown instruction `%.*s`\n",
-                            (int) token.count, token.data);
+                    fprintf(stderr, "ERROR: unknown instruction `%.*s` on line %d\n",
+                            (int) token.count, token.data, line_number);
                     exit(1);
                 }
             }


### PR DESCRIPTION
Close #12 

~~Also batch file now gets list of examples directly from Makefile, so we don't need to maintain two lists.~~
All `*.basm` files from `examples` folder now builds automatically.