### PR TITLE
(#72) Comments after string literals raises an error

### DIFF
--- a/examples/hello.basm
+++ b/examples/hello.basm
@@ -1,5 +1,5 @@
 %include "./examples/natives.hasm"
-%bind hello "Hello, World"
+%bind hello "Hello, World" ; message
 
 push hello
 push 12

--- a/src/bm.h
+++ b/src/bm.h
@@ -1074,8 +1074,9 @@ void basm_translate_source(Basm *basm, String_View input_file_path, size_t level
     // First pass
     while (source.count > 0) {
         String_View line = sv_trim(sv_chop_by_delim(&source, '\n'));
+        line = sv_trim(sv_chop_by_delim(&line, BASM_COMMENT_SYMBOL));
         line_number += 1;
-        if (line.count > 0 && *line.data != BASM_COMMENT_SYMBOL) {
+        if (line.count > 0) {
             String_View token = sv_trim(sv_chop_by_delim(&line, ' '));
 
             // Pre-processor
@@ -1083,10 +1084,8 @@ void basm_translate_source(Basm *basm, String_View input_file_path, size_t level
                 token.count -= 1;
                 token.data  += 1;
                 if (sv_eq(token, sv_from_cstr("bind"))) {
-                    line = sv_trim(line);
                     String_View name = sv_chop_by_delim(&line, ' ');
                     if (name.count > 0) {
-                        line = sv_trim(line);
                         String_View value = line;
                         Word word = {0};
                         if (!basm_translate_literal(basm, value, &word)) {
@@ -1114,8 +1113,6 @@ void basm_translate_source(Basm *basm, String_View input_file_path, size_t level
                         exit(1);
                     }
                 } else if (sv_eq(token, sv_from_cstr("include"))) {
-                    line = sv_trim(line);
-
                     if (line.count > 0) {
                         if (*line.data == '"' && line.data[line.count - 1] == '"') {
                             line.data  += 1;
@@ -1172,8 +1169,7 @@ void basm_translate_source(Basm *basm, String_View input_file_path, size_t level
 
                 // Instruction
                 if (token.count > 0) {
-                    String_View operand = sv_trim(sv_chop_by_delim(&line, BASM_COMMENT_SYMBOL));
-
+                    String_View operand = line;
                     Inst_Type inst_type = INST_NOP;
                     if (inst_by_name(token, &inst_type)) {
                         assert(basm->program_size < BM_PROGRAM_CAPACITY);


### PR DESCRIPTION
Ran into issue while implementing #62 where I could not add a comment after a string literal when doing a `%bind`.
For now, this change will basically ignore anything after the string literal.

Close #72 