### PR TITLE
Introduce basm-mode for vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ Add the following lines to your `.emacs` file:
 (add-to-list 'load-path "/path/to/basm-mode/")
 (require 'basm-mode)
 ```
+
+### Vim
+
+Copy [./tools/basm.vim](./tools/basm.vim) in `.vim/syntax/basm.vim`. Add the following line to your `.vimrc` file:
+
+```vimscript
+autocmd BufRead,BufNewFile *.basm set filetype=basm
+```

--- a/tools/basm.vim
+++ b/tools/basm.vim
@@ -1,0 +1,50 @@
+" Vim syntax file
+" Language: Basm
+
+" Usage Instructions
+" Put this file in .vim/syntax/basm.vim
+" and add in your .vimrc file the next line:
+" autocmd BufRead,BufNewFile *.basm set filetype=basm
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syntax keyword basmTodos TODO XXX FIXME NOTE
+
+" Language keywords
+syntax keyword basmKeywords nop push drop dup
+syntax keyword basmKeywords plusi minusi multi divi modi
+syntax keyword basmKeywords plusf minusf multf divf
+syntax keyword basmKeywords jmp jmp_if halt swap not
+syntax keyword basmKeywords eqi gei gti lei lti nei
+syntax keyword basmKeywords eqf gef gtf lef ltf nef
+syntax keyword basmKeywords ret call native
+syntax keyword basmKeywords andb orb xor shr shl notb
+syntax keyword basmKeywords read8 read16 read32 read64
+syntax keyword basmKeywords write8 write16 write32 write64
+syntax keyword basmKeywords i2f u2f f2i f2u
+
+" Comments
+syntax region basmCommentLine start=";" end="$"   contains=basmTodos
+syntax region basmInclude start="%include" end=" "
+
+" Numbers
+syntax match basmDecInt display "\<[0-9][0-9_]*"
+syntax match basmHexInt display "\<0[xX][0-9a-fA-F][0-9_a-fA-F]*"
+syntax match basmFloat  display "\<[0-9][0-9_]*\%(\.[0-9][0-9_]*\)"
+
+" Strings
+syntax region basmString start=/\v"/ skip=/\v\\./ end=/\v"/
+
+" Set highlights
+highlight default link basmTodos Todo
+highlight default link basmKeywords Keyword
+highlight default link basmCommentLine Comment
+highlight default link basmInclude PreProc
+highlight default link basmDecInt Number
+highlight default link basmHexInt Number
+highlight default link basmFloat Float
+highlight default link basmString String
+
+let b:current_syntax = "basm"


### PR DESCRIPTION
As described by the comment block in the file, it requires the next line in the `.vimrc`:
``` vim
autocmd BufRead,BufNewFile *.basm set filetype=basm
```
and the `basm.vim` file should be placed in the `.vim/syntax/` folder