### PR TITLE
Update basm-mode.el to make jmp_if have the right colouring

### DIFF
--- a/tools/basm-mode.el
+++ b/tools/basm-mode.el
@@ -49,8 +49,8 @@
 
 (let* ((keywords
         '("nop" "push" "drop" "dup" "plusi" "minusi" "multi"
-          "divi" "modi" "plusf" "minusf" "multf" "divf" "jmp"
-          "jmp_if" "halt" "swap" "not" "eqi" "gei" "gti" "lei"
+          "divi" "modi" "plusf" "minusf" "multf" "divf" "jmp_if"
+          "jmp" "halt" "swap" "not" "eqi" "gei" "gti" "lei"
           "lti" "nei" "eqf" "gef" "gtf" "lef" "ltf" "nef" "ret"
           "call" "native" "andb" "orb" "xor" "shr" "shl" "notb"
           "read8" "read16" "read32" "read64" "write8" "write16"

--- a/tools/basm-mode.el
+++ b/tools/basm-mode.el
@@ -56,10 +56,10 @@
           "read8" "read16" "read32" "read64" "write8" "write16"
           "write32" "write64" "i2f" "u2f" "f2i" "f2u"))
        (keywords-regexp
-        (concat "\\<\\("
+        (concat "\\_<\\("
                 (string-join
                  (basm--interleave keywords "\\|"))
-                "\\)\\>")))
+                "\\)\\_>")))
   (setq basm-highlights
         `(("%[[:word:]_]+" . font-lock-preprocessor-face)
           ("[[:word:]_]+\\:" . font-lock-constant-face)


### PR DESCRIPTION
I was going crazy looking at Emacs not colouring `jmp_if` correctly in the files, so I swapped its position with `jmp` in the keywords list.