### PR TITLE
Add comments to asm with labels from basm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         shell: cmd
         # this replaces default PowerShell, which can't fail the build
         run: |
-          ./build_msvc.bat examples
+          ./build_msvc.bat
 # TODO(#21): there is no CI build for FreeBSD
 # TODO(#113): the x86_64 examples do not work on Windows
 # TODO(#114): the x86_64 examples do not work on MacOS

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -4,9 +4,8 @@ rem launch this from msvc-enabled console
 set CFLAGS=/std:c11 /O2 /FC /W4 /WX /wd4996 /nologo /Fe.\build\bin\ /Fo.\build\bin\
 set LIBS=
 
-mkdir build
-mkdir build\bin
-mkdir build\examples
+if not exist build\bin mkdir build\bin
+if not exist build\examples mkdir build\examples
 
 cl.exe %CFLAGS% .\src\basm.c
 cl.exe %CFLAGS% .\src\bme.c
@@ -14,7 +13,8 @@ cl.exe %CFLAGS% .\src\debasm.c
 cl.exe %CFLAGS% .\src\bdb.c
 cl.exe %CFLAGS% .\src\basm2nasm.c
 
-if "%1" == "examples" setlocal EnableDelayedExpansion && for /F "tokens=*" %%e in ('dir /b .\examples\*.basm') do (
+setlocal EnableDelayedExpansion
+for /F "tokens=*" %%e in ('dir /b .\examples\*.basm') do (
     set name=%%e
     ".\build\bin\basm.exe" -g .\examples\%%e .\build\examples\!name:~0,-4!bm
 )

--- a/src/basm2nasm.c
+++ b/src/basm2nasm.c
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
             printf("    mov [stack_top], rsi\n");
         } break;
         case INST_DIVU: {
-            printf("    ;; divi\n");
+            printf("    ;; divu\n");
             printf("    mov rsi, [stack_top]\n");
             printf("    sub rsi, BM_WORD_SIZE\n");
             printf("    mov rbx, [rsi]\n");
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
         } break;
 
         case INST_MODU: {
-            printf("    ;; modi\n");
+            printf("    ;; modu\n");
             printf("    mov rsi, [stack_top]\n");
             printf("    sub rsi, BM_WORD_SIZE\n");
             printf("    mov rbx, [rsi]\n");

--- a/src/basm2nasm.c
+++ b/src/basm2nasm.c
@@ -39,6 +39,13 @@ int main(int argc, char *argv[])
             printf("_start:\n");
         }
 
+        for (size_t j = 0; j < basm.deferred_operands_size; ++j) {
+            if(basm.deferred_operands[j].addr == i) {
+                printf("\n;; "SV_Fmt":\n", SV_Arg(basm.deferred_operands[j].name));
+                break;
+            }
+        }
+
         printf("inst_%zu:\n", i);
         switch (inst.type) {
         case INST_NOP: assert(false && "NOP is not implemented");

--- a/src/basm2nasm.c
+++ b/src/basm2nasm.c
@@ -39,9 +39,11 @@ int main(int argc, char *argv[])
             printf("_start:\n");
         }
 
-        for (size_t j = 0; j < basm.deferred_operands_size; ++j) {
-            if(basm.deferred_operands[j].addr == i) {
-                printf("\n;; "SV_Fmt":\n", SV_Arg(basm.deferred_operands[j].name));
+        for (size_t j = 0; j < BASM_BINDINGS_CAPACITY; ++j) {
+            if (basm.bindings[j].kind != BINDING_LABEL) continue;
+
+            if (basm.bindings[j].value.as_u64 == i) {
+                printf("\n;; "SV_Fmt":\n", SV_Arg(basm.bindings[j].name));
                 break;
             }
         }


### PR DESCRIPTION
`basm2nasm` now prints comments with labels from basm source. That way it's easier to debug x86_64 executable.

~~When I emulate `chars.bm` I get ERR_STACK_UNDERFLOW. So I replaced `ret` with `halt`.~~ Fixed in e68e388

To make scripts more consistent, `build_msvc.bat` rebuilds examples even without argument.
~~Also it can now automatically find and launch MSVC console tools.~~

