### PR TITLE
MINGW support added

### DIFF
--- a/build.c
+++ b/build.c
@@ -1,26 +1,46 @@
 #include "./build.h"
 
 #ifdef _WIN32
-#define CFLAGS "/std:c11", "/O2", "/FC", "/W4", "/WX", "/wd4996", "/nologo", "/Fe.\\build\\bin\\", "/Fo.\\build\\bin\\"
+// Choose only one thing here
+//	#define USE_MINGW
+	#define USE_CL
 #else
-#define CFLAGS "-Wall", "-Wextra", "-Wswitch-enum", "-Wmissing-prototypes", "-Wconversion", "-pedantic", "-fno-strict-aliasing", "-ggdb", "-std=c11"
+	#define USE_LINUX_GCC
 #endif
+
+#ifdef USE_CL
+	#define CFLAGS "/std:c11", "/O2", "/FC", "/W4", "/WX", "/wd4996", "/nologo", "/Fe.\\build\\bin\\", "/Fo.\\build\\bin\\"
+#elif defined(USE_LINUX_GCC)
+	#define CFLAGS "-Wall", "-Wextra", "-Wswitch-enum", "-Wmissing-prototypes", "-Wconversion", "-pedantic", "-fno-strict-aliasing", "-ggdb", "-std=c11"
+#elif defined(USE_MINGW)
+	#define CFLAGS "-Wall", "-Wextra", "-Wswitch-enum", "-Wmissing-prototypes", "-Wconversion", "-pedantic", "-fno-strict-aliasing", "-ggdb", "-std=c11"
+#else
+	#error Choose c-compiller in defines of build.c
+#endif
+
 
 const char *toolchain[] = {
     "basm", "bme", "bmr", "debasm", "bdb", "basm2nasm"
 };
 
-#ifdef _WIN32
+#ifdef USE_CL
 void build_c_file(const char *input_path, const char *output_path)
 {
     CMD("cl.exe", CFLAGS, input_path);
-}
-#else
+} 
+#elif defined(USE_LINUX_GCC)
 void build_c_file(const char *input_path, const char *output_path)
 {
     CMD("cc", CFLAGS, "-o", output_path, input_path);
 }
-#endif // WIN32
+#elif defined(USE_MINGW)
+void build_c_file(const char *input_path, const char *output_path)
+{
+    CMD("gcc.exe", CFLAGS, "-o", output_path, input_path); 
+} 
+#else
+#error Define build_c_file() function for this c-compiler
+#endif 
 
 void build_toolchain(void)
 {


### PR DESCRIPTION
Definition `_WIN32` is not only `cl.exe` , but also, for example, `MINGW`. 
Sometimes other compilation flags are required for `MINGW GCC`, that's why it has its own definition `USE_MINGW` here.
Option `USE_MINGW` tested. Everything except Fibo matches.