### PR TITLE
Dynamic loading of objects on Windows #268

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ debasm
 bdb
 basm2nasm
 build/
+vendor/
 nobuild
 
 *.orig

--- a/nobuild.c
+++ b/nobuild.c
@@ -186,7 +186,31 @@ void wrappers_command(int argc, char **argv)
             PATH("build", "wrappers", "bm_hello.o"));
     }
 #else
-    PANIC("TODO: build C wrappers is not implemented for Windows");
+    // SDL wrapper
+    {
+        CMD("cl.exe", CFLAGS,
+            "/I", PATH("vendor", "sdl2", "include"),
+            "/I", PATH("src", "library"),
+            PATH("wrappers", "bm_sdl.c"),
+            "/link", PATH("vendor", "sdl2", "lib", "SDL2.lib"),
+            "/DLL",
+            CONCAT("/out:", PATH("build", "wrappers", "libbm_sdl.dll")),
+            "/NOENTRY"
+            );
+    }
+
+    // hello wrapper
+    {
+        CMD("cl.exe", CFLAGS,
+            "/I", PATH("src", "library"),
+            PATH("wrappers", "bm_hello.c"),
+            "/link",
+            "/DLL",
+            "libucrt.lib",
+            CONCAT("/out:", PATH("build", "wrappers", "libbm_hello.dll")),
+            "/NOENTRY"
+            );
+    }
 #endif
 }
 

--- a/nobuild.c
+++ b/nobuild.c
@@ -186,6 +186,9 @@ void wrappers_command(int argc, char **argv)
             PATH("build", "wrappers", "bm_hello.o"));
     }
 #else
+    // TODO(#295): consider adding the SDL binary dependency to the repo
+    // It is actually quite common for Windows C/C++ project to have binary blobs in the repos. So there is nothing to be ashamed about.
+
     // SDL wrapper
     {
         CMD("cl.exe", CFLAGS,
@@ -196,7 +199,7 @@ void wrappers_command(int argc, char **argv)
             "/DLL",
             CONCAT("/out:", PATH("build", "wrappers", "libbm_sdl.dll")),
             "/NOENTRY"
-            );
+           );
     }
 
     // hello wrapper
@@ -209,7 +212,7 @@ void wrappers_command(int argc, char **argv)
             "libucrt.lib",
             CONCAT("/out:", PATH("build", "wrappers", "libbm_hello.dll")),
             "/NOENTRY"
-            );
+           );
     }
 #endif
 }

--- a/src/library/bm.h
+++ b/src/library/bm.h
@@ -19,8 +19,10 @@
 // NOTE: Stolen from https://stackoverflow.com/a/3312896
 #if defined(__GNUC__) || defined(__clang__)
 #  define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#  define EXPORT
 #elif defined(_MSC_VER)
 #  define PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop))
+#  define EXPORT __declspec(dllexport)
 #else
 #  error "Packed attributes for struct is not implemented for this compiler. This may result in a program working incorrectly. Feel free to fix that and submit a Pull Request to https://github.com/tsoding/bm"
 #endif

--- a/src/library/native_loader.c
+++ b/src/library/native_loader.c
@@ -1,65 +1,64 @@
 #ifndef _WIN32
 #include <dlfcn.h>
+#else
+#include <windows.h>
 #endif // _WIN32
 
 #include "./native_loader.h"
 
 void native_loader_add_object(Native_Loader *loader, const char *object_path)
 {
-#ifndef _WIN32
     if (loader->objects_size >= NATIVE_LOADER_CAPACITY) {
         fprintf(stderr, "ERROR: Exceeded the capacity of native objects\n");
         exit(1);
     }
-
+#ifndef _WIN32
     void *result = dlopen(object_path, RTLD_LAZY);
     if (result == NULL) {
         fprintf(stderr, "ERROR: could not load object `%s`: %s\n",
                 object_path, dlerror());
         exit(1);
     }
-
+#else
+    HMODULE result = LoadLibraryA(object_path);
+    if (result == NULL) {
+        fprintf(stderr, "ERROR: could not load object %s: %u\n", object_path, GetLastError());
+        exit(1);
+    }
+#endif
     loader->objects[loader->objects_size++] = result;
     printf("INFO: successfully loaded object `%s`\n", object_path);
-#else
-    // TODO(#268): Dynamic loading of objects on Windows
-    (void) loader;
-    (void) object_path;
-    fprintf(stderr, "ERROR: loading dynamic objects in an emulator is not implemented for Windows yet.\n");
-    exit(1);
-#endif
 }
 
 void native_loader_unload_all(Native_Loader *loader)
 {
-#ifndef _WIN32
     for (size_t i = 0; i < loader->objects_size; ++i) {
+#ifndef _WIN32
         if (dlclose(loader->objects[i]) != 0) {
             fprintf(stderr, "ERROR: could not unload object %zu: %s\n", i, dlerror());
             exit(1);
         }
-    }
 #else
-    (void) loader;
+        if (FreeLibrary(loader->objects[i]) == 0) {
+            fprintf(stderr, "ERROR: could not unload object %zu: %u\n", i, GetLastError());
+            exit(1);
+        }
 #endif
+    }
 }
 
 Bm_Native native_loader_find_function(Native_Loader *loader, Arena *arena, const char *function_name)
 {
-#ifndef _WIN32
     for (size_t i = 0; i < loader->objects_size; ++i) {
         Bm_Native result = NULL;
+#ifndef _WIN32
         *(void**)(&result) = dlsym(loader->objects[i], CSTR_CONCAT(arena, "bm_", function_name));
+#else
+        *(void**)(&result) = (void*)GetProcAddress(loader->objects[i], CSTR_CONCAT(arena, "bm_", function_name));
+#endif
         if (result != NULL) {
             return result;
         }
     }
     return NULL;
-#else
-    (void) loader;
-    (void) arena;
-    (void) function_name;
-    fprintf(stderr, "ERROR: loading dynamic objects in an emulator is not implemented for Windows yet.\n");
-    exit(1);
-#endif
 }

--- a/wrappers/bm_hello.c
+++ b/wrappers/bm_hello.c
@@ -2,7 +2,7 @@
 
 #include "bm.h"
 
-Err bm_hello(Bm *bm);
+EXPORT Err bm_hello(Bm *bm);
 
 Err bm_hello(Bm *bm)
 {

--- a/wrappers/bm_sdl.c
+++ b/wrappers/bm_sdl.c
@@ -1,17 +1,17 @@
 #include <SDL2/SDL.h>
 #include "./bm.h"
 
-Err bm_SDL_Init(Bm *bm);
-Err bm_SDL_Quit(Bm *bm);
-Err bm_SDL_CreateWindow(Bm *bm);
-Err bm_SDL_CreateRenderer(Bm *bm);
-Err bm_SDL_PollEvent(Bm *bm);
-Err bm_SDL_SetRenderDrawColor(Bm *bm);
-Err bm_SDL_RenderClear(Bm *bm);
-Err bm_SDL_RenderPresent(Bm *bm);
-Err bm_SDL_RenderFillRect(Bm *bm);
-Err bm_SDL_Delay(Bm *bm);
-Err bm_SDL_GetWindowSize(Bm *bm);
+EXPORT Err bm_SDL_Init(Bm *bm);
+EXPORT Err bm_SDL_Quit(Bm *bm);
+EXPORT Err bm_SDL_CreateWindow(Bm *bm);
+EXPORT Err bm_SDL_CreateRenderer(Bm *bm);
+EXPORT Err bm_SDL_PollEvent(Bm *bm);
+EXPORT Err bm_SDL_SetRenderDrawColor(Bm *bm);
+EXPORT Err bm_SDL_RenderClear(Bm *bm);
+EXPORT Err bm_SDL_RenderPresent(Bm *bm);
+EXPORT Err bm_SDL_RenderFillRect(Bm *bm);
+EXPORT Err bm_SDL_Delay(Bm *bm);
+EXPORT Err bm_SDL_GetWindowSize(Bm *bm);
 
 Err bm_SDL_Init(Bm *bm)
 {


### PR DESCRIPTION
OwO
requires `lib/SDL2.lib` and `include/SDL2/` under `bm/vendor/sdl2`
requires `SDL2.dll` and `libbm_sdl.dll` to run the SDL example