### PR TITLE
(#319) Add `_Statement` suffix to all of the Statement kind types

### DIFF
--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -649,7 +649,7 @@ void basm_translate_include(Basm *basm, Include_Statement include, File_Location
     }
 }
 
-void basm_translate_for(Basm *basm, For phor, File_Location location)
+void basm_translate_for(Basm *basm, For_Statement phor, File_Location location)
 {
     Word from = {0};
     {

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1111,7 +1111,7 @@ void scope_add_macrodef(Scope *scope, Macrodef macrodef)
     scope->macrodefs[scope->macrodefs_size++] = macrodef;
 }
 
-void basm_translate_macro_call(Basm *basm, Macrocall macrocall, File_Location location)
+void basm_translate_macro_call(Basm *basm, Macrocall_Statement macrocall, File_Location location)
 {
     // TODO(#322): no support for recursive macros
     Macrodef *macrodef = basm_resolve_macrodef(basm, macrocall.name);

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -300,11 +300,11 @@ const char *binding_status_as_cstr(Binding_Status status)
     }
 }
 
-void basm_translate_block(Basm *basm, Block *block)
+void basm_translate_block(Basm *basm, Block_Statement *block)
 {
     // first pass begin
     {
-        for (Block *iter = block; iter != NULL; iter = iter->next) {
+        for (Block_Statement *iter = block; iter != NULL; iter = iter->next) {
             Statement statement = iter->statement;
             switch (statement.kind) {
             case STATEMENT_KIND_BIND_LABEL: {
@@ -359,7 +359,7 @@ void basm_translate_block(Basm *basm, Block *block)
 
     // second pass begin
     {
-        for (Block *iter = block; iter != NULL; iter = iter->next) {
+        for (Block_Statement *iter = block; iter != NULL; iter = iter->next) {
             Statement statement = iter->statement;
             switch (statement.kind) {
             case STATEMENT_KIND_EMIT_INST: {
@@ -771,7 +771,7 @@ void basm_translate_source_file(Basm *basm, String_View input_file_path)
         exit(1);
     }
 
-    Block *input_file_block = parse_block_from_lines(&basm->arena, &linizer);
+    Block_Statement *input_file_block = parse_block_from_lines(&basm->arena, &linizer);
     expect_no_lines(&linizer);
     basm_translate_block(basm, input_file_block);
 }

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -630,7 +630,7 @@ void basm_translate_error(Error error, File_Location location)
     exit(1);
 }
 
-void basm_translate_include(Basm *basm, Include include, File_Location location)
+void basm_translate_include(Basm *basm, Include_Statement include, File_Location location)
 {
     {
         String_View resolved_path = SV_NULL;

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -604,7 +604,7 @@ void basm_translate_bind_native(Basm *basm, Bind_Native bind_native, File_Locati
     basm->external_natives_size += 1;
 }
 
-void basm_translate_bind_label(Basm *basm, Bind_Label bind_label, File_Location location)
+void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location)
 {
     basm_bind_value(basm,
                     bind_label.name,

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -396,7 +396,7 @@ void basm_translate_block(Basm *basm, Block_Statement *block)
             break;
 
             case STATEMENT_KIND_MACROCALL:
-                basm_translate_macro_call(basm, statement.value.as_macrocall, statement.location);
+                basm_translate_macrocall_statement(basm, statement.value.as_macrocall, statement.location);
                 break;
 
             case STATEMENT_KIND_MACRODEF:
@@ -1111,7 +1111,7 @@ void scope_add_macrodef(Scope *scope, Macrodef macrodef)
     scope->macrodefs[scope->macrodefs_size++] = macrodef;
 }
 
-void basm_translate_macro_call(Basm *basm, Macrocall_Statement macrocall, File_Location location)
+void basm_translate_macrocall_statement(Basm *basm, Macrocall_Statement macrocall, File_Location location)
 {
     // TODO(#322): no support for recursive macros
     Macrodef *macrodef = basm_resolve_macrodef(basm, macrocall.name);

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -623,7 +623,7 @@ void basm_translate_assert(Basm *basm, Assert_Statement azzert, File_Location lo
     };
 }
 
-void basm_translate_error(Error error, File_Location location)
+void basm_translate_error(Error_Statement error, File_Location location)
 {
     fprintf(stderr, FL_Fmt": ERROR: "SV_Fmt"\n",
             FL_Arg(location), SV_Arg(error.message));

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -534,7 +534,7 @@ void basm_eval_deferred_entry(Basm *basm)
     basm->scope = saved_basm_scope;
 }
 
-void basm_translate_emit_inst(Basm *basm, Emit_Inst emit_inst, File_Location location)
+void basm_translate_emit_inst(Basm *basm, Emit_Inst_Statement emit_inst, File_Location location)
 {
     assert(basm->program_size < BM_PROGRAM_CAPACITY);
     basm->program[basm->program_size].type = emit_inst.type;

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -546,7 +546,7 @@ void basm_translate_emit_inst(Basm *basm, Emit_Inst_Statement emit_inst, File_Lo
     basm->program_size += 1;
 }
 
-void basm_translate_entry(Basm *basm, Entry entry, File_Location location)
+void basm_translate_entry(Basm *basm, Entry_Statement entry, File_Location location)
 {
     assert(basm->scope);
 

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -571,7 +571,7 @@ void basm_translate_entry(Basm *basm, Entry entry, File_Location location)
     basm->deferred_entry.scope = basm->scope;
 }
 
-void basm_translate_bind_const(Basm *basm, Bind_Const bind_const, File_Location location)
+void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File_Location location)
 {
     basm_bind_expr(basm,
                    bind_const.name,

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -699,7 +699,7 @@ void basm_translate_for(Basm *basm, For phor, File_Location location)
     }
 }
 
-void basm_translate_if(Basm *basm, If eef, File_Location location)
+void basm_translate_if(Basm *basm, If_Statement eef, File_Location location)
 {
     Word condition = {0};
     Eval_Status status = basm_expr_eval(basm, eef.condition, location, &condition);

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -613,7 +613,7 @@ void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File
                     location);
 }
 
-void basm_translate_assert(Basm *basm, Assert azzert, File_Location location)
+void basm_translate_assert(Basm *basm, Assert_Statement azzert, File_Location location)
 {
     assert(basm->scope != NULL);
     basm->deferred_asserts[basm->deferred_asserts_size++] = (Deferred_Assert) {

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -580,7 +580,7 @@ void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File
                    location);
 }
 
-void basm_translate_bind_native(Basm *basm, Bind_Native bind_native, File_Location location)
+void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location)
 {
     if (bind_native.name.count >= NATIVE_NAME_CAPACITY - 1) {
         fprintf(stderr, FL_Fmt": ERROR: exceed maximum size of the name for a native function. The limit is %zu.\n", FL_Arg(location), (size_t) (NATIVE_NAME_CAPACITY - 1));

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -178,7 +178,7 @@ void basm_translate_assert(Basm *basm, Assert_Statement azzert, File_Location lo
 void basm_translate_error(Error_Statement error, File_Location location);
 void basm_translate_entry(Basm *basm, Entry_Statement entry, File_Location location);
 void basm_translate_emit_inst(Basm *basm, Emit_Inst_Statement emit_inst, File_Location location);
-void basm_translate_for(Basm *basm, For phor, File_Location location);
+void basm_translate_for(Basm *basm, For_Statement phor, File_Location location);
 void basm_translate_source_file(Basm *basm, String_View input_file_path);
 void basm_translate_root_source_file(Basm *basm, String_View input_file_path);
 

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -175,7 +175,7 @@ void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, F
 void basm_translate_if(Basm *basm, If eef, File_Location location);
 void basm_translate_include(Basm *basm, Include_Statement include, File_Location location);
 void basm_translate_assert(Basm *basm, Assert_Statement azzert, File_Location location);
-void basm_translate_error(Error error, File_Location location);
+void basm_translate_error(Error_Statement error, File_Location location);
 void basm_translate_entry(Basm *basm, Entry entry, File_Location location);
 void basm_translate_emit_inst(Basm *basm, Emit_Inst_Statement emit_inst, File_Location location);
 void basm_translate_for(Basm *basm, For phor, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -174,7 +174,7 @@ void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File
 void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location);
 void basm_translate_if(Basm *basm, If eef, File_Location location);
 void basm_translate_include(Basm *basm, Include_Statement include, File_Location location);
-void basm_translate_assert(Basm *basm, Assert azzert, File_Location location);
+void basm_translate_assert(Basm *basm, Assert_Statement azzert, File_Location location);
 void basm_translate_error(Error error, File_Location location);
 void basm_translate_entry(Basm *basm, Entry entry, File_Location location);
 void basm_translate_emit_inst(Basm *basm, Emit_Inst_Statement emit_inst, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -171,7 +171,7 @@ void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, 
 void basm_translate_block(Basm *basm, Block *block);
 void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File_Location location);
 void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location);
-void basm_translate_bind_native(Basm *basm, Bind_Native bind_native, File_Location location);
+void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location);
 void basm_translate_if(Basm *basm, If eef, File_Location location);
 void basm_translate_include(Basm *basm, Include include, File_Location location);
 void basm_translate_assert(Basm *basm, Assert azzert, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -177,7 +177,7 @@ void basm_translate_include(Basm *basm, Include include, File_Location location)
 void basm_translate_assert(Basm *basm, Assert azzert, File_Location location);
 void basm_translate_error(Error error, File_Location location);
 void basm_translate_entry(Basm *basm, Entry entry, File_Location location);
-void basm_translate_emit_inst(Basm *basm, Emit_Inst emit_inst, File_Location location);
+void basm_translate_emit_inst(Basm *basm, Emit_Inst_Statement emit_inst, File_Location location);
 void basm_translate_for(Basm *basm, For phor, File_Location location);
 void basm_translate_source_file(Basm *basm, String_View input_file_path);
 void basm_translate_root_source_file(Basm *basm, String_View input_file_path);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -169,7 +169,7 @@ Macrodef *basm_resolve_macrodef(Basm *basm, String_View name);
 void basm_translate_macro_call(Basm *basm, Macrocall macrocall, File_Location location);
 void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, File_Location location);
 void basm_translate_block(Basm *basm, Block *block);
-void basm_translate_bind_const(Basm *basm, Bind_Const bind_const, File_Location location);
+void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File_Location location);
 void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location);
 void basm_translate_bind_native(Basm *basm, Bind_Native bind_native, File_Location location);
 void basm_translate_if(Basm *basm, If eef, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -173,7 +173,7 @@ void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File
 void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location);
 void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location);
 void basm_translate_if(Basm *basm, If eef, File_Location location);
-void basm_translate_include(Basm *basm, Include include, File_Location location);
+void basm_translate_include(Basm *basm, Include_Statement include, File_Location location);
 void basm_translate_assert(Basm *basm, Assert azzert, File_Location location);
 void basm_translate_error(Error error, File_Location location);
 void basm_translate_entry(Basm *basm, Entry entry, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -166,7 +166,7 @@ bool basm_resolve_include_file_path(Basm *basm,
                                     String_View file_path,
                                     String_View *resolved_path);
 Macrodef *basm_resolve_macrodef(Basm *basm, String_View name);
-void basm_translate_macro_call(Basm *basm, Macrocall macrocall, File_Location location);
+void basm_translate_macro_call(Basm *basm, Macrocall_Statement macrocall, File_Location location);
 void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, File_Location location);
 void basm_translate_block(Basm *basm, Block_Statement *block);
 void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -176,7 +176,7 @@ void basm_translate_if(Basm *basm, If eef, File_Location location);
 void basm_translate_include(Basm *basm, Include_Statement include, File_Location location);
 void basm_translate_assert(Basm *basm, Assert_Statement azzert, File_Location location);
 void basm_translate_error(Error_Statement error, File_Location location);
-void basm_translate_entry(Basm *basm, Entry entry, File_Location location);
+void basm_translate_entry(Basm *basm, Entry_Statement entry, File_Location location);
 void basm_translate_emit_inst(Basm *basm, Emit_Inst_Statement emit_inst, File_Location location);
 void basm_translate_for(Basm *basm, For phor, File_Location location);
 void basm_translate_source_file(Basm *basm, String_View input_file_path);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -64,7 +64,7 @@ typedef struct Scope Scope;
 typedef struct {
     String_View name;
     Fundef_Arg *args;
-    Block *body;
+    Block_Statement *body;
     File_Location location;
     Scope *scope;
 } Macrodef;
@@ -168,7 +168,7 @@ bool basm_resolve_include_file_path(Basm *basm,
 Macrodef *basm_resolve_macrodef(Basm *basm, String_View name);
 void basm_translate_macro_call(Basm *basm, Macrocall macrocall, File_Location location);
 void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, File_Location location);
-void basm_translate_block(Basm *basm, Block *block);
+void basm_translate_block(Basm *basm, Block_Statement *block);
 void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File_Location location);
 void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location);
 void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -172,7 +172,7 @@ void basm_translate_block(Basm *basm, Block_Statement *block);
 void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File_Location location);
 void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location);
 void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location);
-void basm_translate_if(Basm *basm, If eef, File_Location location);
+void basm_translate_if(Basm *basm, If_Statement eef, File_Location location);
 void basm_translate_include(Basm *basm, Include_Statement include, File_Location location);
 void basm_translate_assert(Basm *basm, Assert_Statement azzert, File_Location location);
 void basm_translate_error(Error_Statement error, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -170,7 +170,7 @@ void basm_translate_macro_call(Basm *basm, Macrocall macrocall, File_Location lo
 void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, File_Location location);
 void basm_translate_block(Basm *basm, Block *block);
 void basm_translate_bind_const(Basm *basm, Bind_Const bind_const, File_Location location);
-void basm_translate_bind_label(Basm *basm, Bind_Label bind_label, File_Location location);
+void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location);
 void basm_translate_bind_native(Basm *basm, Bind_Native bind_native, File_Location location);
 void basm_translate_if(Basm *basm, If eef, File_Location location);
 void basm_translate_include(Basm *basm, Include include, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -166,7 +166,9 @@ bool basm_resolve_include_file_path(Basm *basm,
                                     String_View file_path,
                                     String_View *resolved_path);
 Macrodef *basm_resolve_macrodef(Basm *basm, String_View name);
-void basm_translate_macro_call(Basm *basm, Macrocall_Statement macrocall, File_Location location);
+// TODO(#326): all the `basm_translate_*` functions that translate statements should have the name `basm_translate_<statement-type-in-lower-case>`
+// Like `basm_translate_macrocall_statement` or `basm_translate_macrodef_statement`
+void basm_translate_macrocall_statement(Basm *basm, Macrocall_Statement macrocall, File_Location location);
 void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, File_Location location);
 void basm_translate_block(Basm *basm, Block_Statement *block);
 void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File_Location location);

--- a/src/library/statement.c
+++ b/src/library/statement.c
@@ -1,6 +1,6 @@
 #include "./statement.h"
 
-void dump_block(FILE *stream, Block *block, int level)
+void dump_block(FILE *stream, Block_Statement *block, int level)
 {
     fprintf(stream, "%*sBlock:\n", level * 2, "");
     while (block != NULL) {
@@ -128,7 +128,7 @@ void dump_statement(FILE *stream, Statement statement, int level)
     }
 }
 
-int dump_block_as_dot_edges(FILE *stream, Block *block, int *counter)
+int dump_block_as_dot_edges(FILE *stream, Block_Statement *block, int *counter)
 {
     int id = (*counter)++;
 
@@ -446,13 +446,13 @@ void block_list_push(Arena *arena, Block_List *list, Statement statement)
 
     if (list->end == NULL) {
         assert(list->begin == NULL);
-        Block *block = arena_alloc(arena, sizeof(Block));
+        Block_Statement *block = arena_alloc(arena, sizeof(Block_Statement));
         block->statement = statement;
         list->begin = block;
         list->end = block;
     } else {
         assert(list->begin != NULL);
-        Block *block = arena_alloc(arena, sizeof(Block));
+        Block_Statement *block = arena_alloc(arena, sizeof(Block_Statement));
         block->statement = statement;
         list->end->next = block;
         list->end = block;
@@ -765,7 +765,7 @@ static bool is_block_stop_directive(Line_Directive directive)
            || sv_eq(directive.name, SV("elif"));
 }
 
-Block *parse_block_from_lines(Arena *arena, Linizer *linizer)
+Block_Statement *parse_block_from_lines(Arena *arena, Linizer *linizer)
 {
     Block_List result = {0};
 

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -65,7 +65,7 @@ typedef struct {
     Expr condition;
     Block_Statement *then;
     Block_Statement *elze;
-} If;
+} If_Statement;
 
 typedef struct {
     String_View var;
@@ -102,7 +102,7 @@ typedef union {
     Error_Statement as_error;
     Entry_Statement as_entry;
     Block_Statement *as_block;
-    If as_if;
+    If_Statement as_if;
     Block_Statement *as_scope;
     For as_for;
     Fundef as_fundef;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -7,7 +7,7 @@
 
 typedef struct Statement Statement;
 typedef struct Block_Statement Block_Statement;
-typedef struct Fundef Fundef;
+typedef struct Fundef_Statement Fundef_Statement;
 
 typedef enum {
     STATEMENT_KIND_EMIT_INST,
@@ -74,7 +74,7 @@ typedef struct {
     Block_Statement *body;
 } For_Statement;
 
-struct Fundef {
+struct Fundef_Statement {
     String_View name;
     Fundef_Arg *args;
     Expr *guard;
@@ -105,7 +105,7 @@ typedef union {
     If_Statement as_if;
     Block_Statement *as_scope;
     For_Statement as_for;
-    Fundef as_fundef;
+    Fundef_Statement as_fundef;
     Macrocall as_macrocall;
     // TODO(#319): all of the Statement kind types should have the `_Statement` suffix
     // Not only Macrodef_Statement.

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -34,7 +34,7 @@ typedef struct {
 
 typedef struct {
     String_View name;
-} Bind_Label;
+} Bind_Label_Statement;
 
 typedef struct {
     String_View name;
@@ -94,7 +94,7 @@ typedef struct {
 
 typedef union {
     Emit_Inst_Statement as_emit_inst;
-    Bind_Label as_bind_label;
+    Bind_Label_Statement as_bind_label;
     Bind_Const as_bind_const;
     Bind_Native as_bind_native;
     Include as_include;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -55,7 +55,7 @@ typedef struct {
 
 typedef struct {
     String_View message;
-} Error;
+} Error_Statement;
 
 typedef struct {
     Expr value;
@@ -99,7 +99,7 @@ typedef union {
     Bind_Native_Statement as_bind_native;
     Include_Statement as_include;
     Assert_Statement as_assert;
-    Error as_error;
+    Error_Statement as_error;
     Entry as_entry;
     Block *as_block;
     If as_if;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -43,7 +43,7 @@ typedef struct {
 
 typedef struct {
     String_View name;
-} Bind_Native;
+} Bind_Native_Statement;
 
 typedef struct {
     String_View path;
@@ -96,7 +96,7 @@ typedef union {
     Emit_Inst_Statement as_emit_inst;
     Bind_Label_Statement as_bind_label;
     Bind_Const_Statement as_bind_const;
-    Bind_Native as_bind_native;
+    Bind_Native_Statement as_bind_native;
     Include as_include;
     Assert as_assert;
     Error as_error;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -59,7 +59,7 @@ typedef struct {
 
 typedef struct {
     Expr value;
-} Entry;
+} Entry_Statement;
 
 typedef struct {
     Expr condition;
@@ -100,7 +100,7 @@ typedef union {
     Include_Statement as_include;
     Assert_Statement as_assert;
     Error_Statement as_error;
-    Entry as_entry;
+    Entry_Statement as_entry;
     Block *as_block;
     If as_if;
     Block *as_scope;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -30,7 +30,7 @@ typedef enum {
 typedef struct {
     Inst_Type type;
     Expr operand;
-} Emit_Inst;
+} Emit_Inst_Statement;
 
 typedef struct {
     String_View name;
@@ -93,7 +93,7 @@ typedef struct {
 } Macrodef_Statement;
 
 typedef union {
-    Emit_Inst as_emit_inst;
+    Emit_Inst_Statement as_emit_inst;
     Bind_Label as_bind_label;
     Bind_Const as_bind_const;
     Bind_Native as_bind_native;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -84,7 +84,7 @@ struct Fundef_Statement {
 typedef struct {
     String_View name;
     Funcall_Arg *args;
-} Macrocall;
+} Macrocall_Statement;
 
 typedef struct {
     String_View name;
@@ -106,7 +106,7 @@ typedef union {
     Block_Statement *as_scope;
     For_Statement as_for;
     Fundef_Statement as_fundef;
-    Macrocall as_macrocall;
+    Macrocall_Statement as_macrocall;
     // TODO(#319): all of the Statement kind types should have the `_Statement` suffix
     // Not only Macrodef_Statement.
     Macrodef_Statement as_macrodef;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -94,7 +94,7 @@ typedef struct {
 
 typedef union {
     Emit_Inst_Statement as_emit_inst;
-    // TODO: Remove redundant prefix `bind` from *_Statement types
+    // TODO(#327): Remove redundant prefix `bind` from *_Statement types
     Bind_Label_Statement as_bind_label;
     Bind_Const_Statement as_bind_const;
     Bind_Native_Statement as_bind_native;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -6,7 +6,7 @@
 #include "./linizer.h"
 
 typedef struct Statement Statement;
-typedef struct Block Block;
+typedef struct Block_Statement Block_Statement;
 typedef struct Fundef Fundef;
 
 typedef enum {
@@ -63,15 +63,15 @@ typedef struct {
 
 typedef struct {
     Expr condition;
-    Block *then;
-    Block *elze;
+    Block_Statement *then;
+    Block_Statement *elze;
 } If;
 
 typedef struct {
     String_View var;
     Expr from;
     Expr to;
-    Block *body;
+    Block_Statement *body;
 } For;
 
 struct Fundef {
@@ -89,7 +89,7 @@ typedef struct {
 typedef struct {
     String_View name;
     Fundef_Arg *args;
-    Block *body;
+    Block_Statement *body;
 } Macrodef_Statement;
 
 typedef union {
@@ -101,9 +101,9 @@ typedef union {
     Assert_Statement as_assert;
     Error_Statement as_error;
     Entry_Statement as_entry;
-    Block *as_block;
+    Block_Statement *as_block;
     If as_if;
-    Block *as_scope;
+    Block_Statement *as_scope;
     For as_for;
     Fundef as_fundef;
     Macrocall as_macrocall;
@@ -118,27 +118,27 @@ struct Statement {
     File_Location location;
 };
 
-struct Block {
+struct Block_Statement {
     Statement statement;
-    Block *next;
+    Block_Statement *next;
 };
 
 typedef struct {
-    Block *begin;
-    Block *end;
+    Block_Statement *begin;
+    Block_Statement *end;
 } Block_List;
 
 void block_list_push(Arena *arena, Block_List *list, Statement statement);
 
-void dump_block(FILE *stream, Block *block, int level);
+void dump_block(FILE *stream, Block_Statement *block, int level);
 void dump_statement(FILE *stream, Statement statement, int level);
-int dump_block_as_dot_edges(FILE *stream, Block *block, int *counter);
+int dump_block_as_dot_edges(FILE *stream, Block_Statement *block, int *counter);
 int dump_statement_as_dot_edges(FILE *stream, Statement statement, int *counter);
 void dump_statement_as_dot(FILE *stream, Statement statement);
 
 Statement parse_if_else_body_from_lines(Arena *arena, Linizer *linizer,
                                         Expr condition, File_Location location);
 void parse_directive_from_line(Arena *arena, Linizer *linizer, Block_List *output);
-Block *parse_block_from_lines(Arena *arena, Linizer *linizer);
+Block_Statement *parse_block_from_lines(Arena *arena, Linizer *linizer);
 
 #endif // STATEMENT_H_

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -51,7 +51,7 @@ typedef struct {
 
 typedef struct {
     Expr condition;
-} Assert;
+} Assert_Statement;
 
 typedef struct {
     String_View message;
@@ -98,7 +98,7 @@ typedef union {
     Bind_Const_Statement as_bind_const;
     Bind_Native_Statement as_bind_native;
     Include_Statement as_include;
-    Assert as_assert;
+    Assert_Statement as_assert;
     Error as_error;
     Entry as_entry;
     Block *as_block;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -94,6 +94,7 @@ typedef struct {
 
 typedef union {
     Emit_Inst_Statement as_emit_inst;
+    // TODO: Remove redundant prefix `bind` from *_Statement types
     Bind_Label_Statement as_bind_label;
     Bind_Const_Statement as_bind_const;
     Bind_Native_Statement as_bind_native;
@@ -107,8 +108,6 @@ typedef union {
     For_Statement as_for;
     Fundef_Statement as_fundef;
     Macrocall_Statement as_macrocall;
-    // TODO(#319): all of the Statement kind types should have the `_Statement` suffix
-    // Not only Macrodef_Statement.
     Macrodef_Statement as_macrodef;
 } Statement_Value;
 

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -39,7 +39,7 @@ typedef struct {
 typedef struct {
     String_View name;
     Expr value;
-} Bind_Const;
+} Bind_Const_Statement;
 
 typedef struct {
     String_View name;
@@ -95,7 +95,7 @@ typedef struct {
 typedef union {
     Emit_Inst_Statement as_emit_inst;
     Bind_Label_Statement as_bind_label;
-    Bind_Const as_bind_const;
+    Bind_Const_Statement as_bind_const;
     Bind_Native as_bind_native;
     Include as_include;
     Assert as_assert;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -72,7 +72,7 @@ typedef struct {
     Expr from;
     Expr to;
     Block_Statement *body;
-} For;
+} For_Statement;
 
 struct Fundef {
     String_View name;
@@ -104,7 +104,7 @@ typedef union {
     Block_Statement *as_block;
     If_Statement as_if;
     Block_Statement *as_scope;
-    For as_for;
+    For_Statement as_for;
     Fundef as_fundef;
     Macrocall as_macrocall;
     // TODO(#319): all of the Statement kind types should have the `_Statement` suffix

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -47,7 +47,7 @@ typedef struct {
 
 typedef struct {
     String_View path;
-} Include;
+} Include_Statement;
 
 typedef struct {
     Expr condition;
@@ -97,7 +97,7 @@ typedef union {
     Bind_Label_Statement as_bind_label;
     Bind_Const_Statement as_bind_const;
     Bind_Native_Statement as_bind_native;
-    Include as_include;
+    Include_Statement as_include;
     Assert as_assert;
     Error as_error;
     Entry as_entry;


### PR DESCRIPTION
Close #319 

On stream you [mentioned](https://www.twitch.tv/videos/994203851?t=00h38m04s) `Bind_` suffix in some of those types. So I also added this:
```
// TODO: Remove redundant prefix `bind` from *_Statement types
```