### PR TITLE
(#327) Remove `bind` prefix from statement types and all derived names

### DIFF
--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -312,9 +312,9 @@ void basm_translate_block(Basm *basm, Block_Statement *block)
         for (Block_Statement *iter = block; iter != NULL; iter = iter->next) {
             Statement statement = iter->statement;
             switch (statement.kind) {
-            case STATEMENT_KIND_BIND_LABEL: {
+            case STATEMENT_KIND_LABEL: {
                 basm_defer_binding(basm,
-                                   statement.value.as_bind_label.name,
+                                   statement.value.as_label.name,
                                    BINDING_LABEL,
                                    statement.location);
             }
@@ -372,8 +372,8 @@ void basm_translate_block(Basm *basm, Block_Statement *block)
             }
             break;
 
-            case STATEMENT_KIND_BIND_LABEL: {
-                Binding *binding = basm_resolve_binding(basm, statement.value.as_bind_label.name);
+            case STATEMENT_KIND_LABEL: {
+                Binding *binding = basm_resolve_binding(basm, statement.value.as_label.name);
                 assert(binding != NULL);
                 assert(binding->kind == BINDING_LABEL);
                 assert(binding->status == BINDING_DEFERRED);
@@ -609,10 +609,10 @@ void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, F
     basm->external_natives_size += 1;
 }
 
-void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location)
+void basm_translate_bind_label(Basm *basm, Label_Statement label, File_Location location)
 {
     basm_bind_value(basm,
-                    bind_label.name,
+                    label.name,
                     word_u64(basm->program_size),
                     BINDING_LABEL,
                     location);

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -322,8 +322,8 @@ void basm_translate_block(Basm *basm, Block_Statement *block)
             case STATEMENT_KIND_CONST:
                 basm_translate_const(basm, statement.value.as_const, statement.location);
                 break;
-            case STATEMENT_KIND_BIND_NATIVE:
-                basm_translate_bind_native(basm, statement.value.as_bind_native, statement.location);
+            case STATEMENT_KIND_NATIVE:
+                basm_translate_native(basm, statement.value.as_native, statement.location);
                 break;
             case STATEMENT_KIND_INCLUDE:
                 basm_translate_include(basm, statement.value.as_include, statement.location);
@@ -405,7 +405,7 @@ void basm_translate_block(Basm *basm, Block_Statement *block)
                 break;
 
             case STATEMENT_KIND_MACRODEF:
-            case STATEMENT_KIND_BIND_NATIVE:
+            case STATEMENT_KIND_NATIVE:
             case STATEMENT_KIND_FUNCDEF:
             case STATEMENT_KIND_BLOCK:
             case STATEMENT_KIND_ENTRY:
@@ -585,9 +585,9 @@ void basm_translate_const(Basm *basm, Const_Statement konst, File_Location locat
                    location);
 }
 
-void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location)
+void basm_translate_native(Basm *basm, Native_Statement native, File_Location location)
 {
-    if (bind_native.name.count >= NATIVE_NAME_CAPACITY - 1) {
+    if (native.name.count >= NATIVE_NAME_CAPACITY - 1) {
         fprintf(stderr, FL_Fmt": ERROR: exceed maximum size of the name for a native function. The limit is %zu.\n", FL_Arg(location), (size_t) (NATIVE_NAME_CAPACITY - 1));
         exit(1);
     }
@@ -597,11 +597,11 @@ void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, F
            NATIVE_NAME_CAPACITY);
 
     memcpy(basm->external_natives[basm->external_natives_size].name,
-           bind_native.name.data,
-           bind_native.name.count);
+           native.name.data,
+           native.name.count);
 
     basm_bind_value(basm,
-                    bind_native.name,
+                    native.name,
                     word_u64(basm->external_natives_size),
                     BINDING_NATIVE,
                     location);

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -319,8 +319,8 @@ void basm_translate_block(Basm *basm, Block_Statement *block)
                                    statement.location);
             }
             break;
-            case STATEMENT_KIND_BIND_CONST:
-                basm_translate_bind_const(basm, statement.value.as_bind_const, statement.location);
+            case STATEMENT_KIND_CONST:
+                basm_translate_const(basm, statement.value.as_const, statement.location);
                 break;
             case STATEMENT_KIND_BIND_NATIVE:
                 basm_translate_bind_native(basm, statement.value.as_bind_native, statement.location);
@@ -412,7 +412,7 @@ void basm_translate_block(Basm *basm, Block_Statement *block)
             case STATEMENT_KIND_ERROR:
             case STATEMENT_KIND_ASSERT:
             case STATEMENT_KIND_INCLUDE:
-            case STATEMENT_KIND_BIND_CONST:
+            case STATEMENT_KIND_CONST:
                 // NOTE: ignored at the second pass
                 break;
 
@@ -576,11 +576,11 @@ void basm_translate_entry(Basm *basm, Entry_Statement entry, File_Location locat
     basm->deferred_entry.scope = basm->scope;
 }
 
-void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File_Location location)
+void basm_translate_const(Basm *basm, Const_Statement konst, File_Location location)
 {
     basm_bind_expr(basm,
-                   bind_const.name,
-                   bind_const.value,
+                   konst.name,
+                   konst.value,
                    BINDING_CONST,
                    location);
 }

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -609,15 +609,6 @@ void basm_translate_native(Basm *basm, Native_Statement native, File_Location lo
     basm->external_natives_size += 1;
 }
 
-void basm_translate_bind_label(Basm *basm, Label_Statement label, File_Location location)
-{
-    basm_bind_value(basm,
-                    label.name,
-                    word_u64(basm->program_size),
-                    BINDING_LABEL,
-                    location);
-}
-
 void basm_translate_assert(Basm *basm, Assert_Statement azzert, File_Location location)
 {
     assert(basm->scope != NULL);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -173,7 +173,7 @@ void basm_translate_macrocall_statement(Basm *basm, Macrocall_Statement macrocal
 void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, File_Location location);
 void basm_translate_block(Basm *basm, Block_Statement *block);
 void basm_translate_const(Basm *basm, Const_Statement konst, File_Location location);
-void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location);
+void basm_translate_label(Basm *basm, Label_Statement label, File_Location location);
 void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location);
 void basm_translate_if(Basm *basm, If_Statement eef, File_Location location);
 void basm_translate_include(Basm *basm, Include_Statement include, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -173,7 +173,6 @@ void basm_translate_macrocall_statement(Basm *basm, Macrocall_Statement macrocal
 void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, File_Location location);
 void basm_translate_block(Basm *basm, Block_Statement *block);
 void basm_translate_const(Basm *basm, Const_Statement konst, File_Location location);
-void basm_translate_label(Basm *basm, Label_Statement label, File_Location location);
 void basm_translate_native(Basm *basm, Native_Statement native, File_Location location);
 void basm_translate_if(Basm *basm, If_Statement eef, File_Location location);
 void basm_translate_include(Basm *basm, Include_Statement include, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -172,7 +172,7 @@ Macrodef *basm_resolve_macrodef(Basm *basm, String_View name);
 void basm_translate_macrocall_statement(Basm *basm, Macrocall_Statement macrocall, File_Location location);
 void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, File_Location location);
 void basm_translate_block(Basm *basm, Block_Statement *block);
-void basm_translate_bind_const(Basm *basm, Bind_Const_Statement bind_const, File_Location location);
+void basm_translate_const(Basm *basm, Const_Statement konst, File_Location location);
 void basm_translate_bind_label(Basm *basm, Bind_Label_Statement bind_label, File_Location location);
 void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location);
 void basm_translate_if(Basm *basm, If_Statement eef, File_Location location);

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -174,7 +174,7 @@ void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, 
 void basm_translate_block(Basm *basm, Block_Statement *block);
 void basm_translate_const(Basm *basm, Const_Statement konst, File_Location location);
 void basm_translate_label(Basm *basm, Label_Statement label, File_Location location);
-void basm_translate_bind_native(Basm *basm, Bind_Native_Statement bind_native, File_Location location);
+void basm_translate_native(Basm *basm, Native_Statement native, File_Location location);
 void basm_translate_if(Basm *basm, If_Statement eef, File_Location location);
 void basm_translate_include(Basm *basm, Include_Statement include, File_Location location);
 void basm_translate_assert(Basm *basm, Assert_Statement azzert, File_Location location);

--- a/src/library/statement.c
+++ b/src/library/statement.c
@@ -32,11 +32,11 @@ void dump_statement(FILE *stream, Statement statement, int level)
     }
     break;
 
-    case STATEMENT_KIND_BIND_CONST: {
-        String_View name = statement.value.as_bind_const.name;
-        Expr value = statement.value.as_bind_const.value;
+    case STATEMENT_KIND_CONST: {
+        String_View name = statement.value.as_const.name;
+        Expr value = statement.value.as_const.value;
 
-        fprintf(stream, "%*sBind Const:\n", level * 2, "");
+        fprintf(stream, "%*sConst:\n", level * 2, "");
         fprintf(stream, "%*sName: "SV_Fmt"\n", (level + 1) * 2, "", SV_Arg(name));
         fprintf(stream, "%*sValue:\n", (level + 1) * 2, "");
         dump_expr(stream, value, level + 2);
@@ -177,10 +177,10 @@ int dump_statement_as_dot_edges(FILE *stream, Statement statement, int *counter)
     }
     break;
 
-    case STATEMENT_KIND_BIND_CONST: {
+    case STATEMENT_KIND_CONST: {
         int id = (*counter)++;
-        String_View name = statement.value.as_bind_const.name;
-        Expr value = statement.value.as_bind_const.value;
+        String_View name = statement.value.as_const.name;
+        Expr value = statement.value.as_const.value;
 
         fprintf(stream, "Expr_%d [shape=diamond label=\"%%const "SV_Fmt"\"]\n",
                 id, SV_Arg(name));
@@ -542,7 +542,7 @@ void parse_directive_from_line(Arena *arena, Linizer *linizer, Block_List *outpu
     } else if (sv_eq(name, sv_from_cstr("const"))) {
         Statement statement = {0};
         statement.location = location;
-        statement.kind = STATEMENT_KIND_BIND_CONST;
+        statement.kind = STATEMENT_KIND_CONST;
 
         Tokenizer tokenizer = tokenizer_from_sv(body);
         Expr binding_name = parse_expr_from_tokens(arena, &tokenizer, location);
@@ -551,11 +551,11 @@ void parse_directive_from_line(Arena *arena, Linizer *linizer, Block_List *outpu
                     FL_Arg(location));
             exit(1);
         }
-        statement.value.as_bind_const.name = binding_name.value.as_binding;
+        statement.value.as_const.name = binding_name.value.as_binding;
 
         expect_token_next(&tokenizer, TOKEN_KIND_EQ, location);
 
-        statement.value.as_bind_const.value =
+        statement.value.as_const.value =
             parse_expr_from_tokens(arena, &tokenizer, location);
         expect_no_tokens(&tokenizer, location);
 

--- a/src/library/statement.c
+++ b/src/library/statement.c
@@ -43,8 +43,8 @@ void dump_statement(FILE *stream, Statement statement, int level)
     }
     break;
 
-    case STATEMENT_KIND_BIND_NATIVE: {
-        assert(false && "TODO(#275): dumping Bind Native statement is not implemented");
+    case STATEMENT_KIND_NATIVE: {
+        assert(false && "TODO(#275): dumping Native statement is not implemented");
         exit(1);
     }
     break;
@@ -190,9 +190,9 @@ int dump_statement_as_dot_edges(FILE *stream, Statement statement, int *counter)
     }
     break;
 
-    case STATEMENT_KIND_BIND_NATIVE: {
+    case STATEMENT_KIND_NATIVE: {
         int id = (*counter)++;
-        String_View name = statement.value.as_bind_native.name;
+        String_View name = statement.value.as_native.name;
 
         fprintf(stream, "Expr_%d [shape=diamond label=\"%%native "SV_Fmt"\"]\n",
                 id, SV_Arg(name));
@@ -563,7 +563,7 @@ void parse_directive_from_line(Arena *arena, Linizer *linizer, Block_List *outpu
     } else if (sv_eq(name, sv_from_cstr("native"))) {
         Statement statement = {0};
         statement.location = location;
-        statement.kind = STATEMENT_KIND_BIND_NATIVE;
+        statement.kind = STATEMENT_KIND_NATIVE;
 
         Tokenizer tokenizer = tokenizer_from_sv(body);
         Expr binding_name = parse_expr_from_tokens(arena, &tokenizer, location);
@@ -572,7 +572,7 @@ void parse_directive_from_line(Arena *arena, Linizer *linizer, Block_List *outpu
                     FL_Arg(location));
             exit(1);
         }
-        statement.value.as_bind_native.name = binding_name.value.as_binding;
+        statement.value.as_native.name = binding_name.value.as_binding;
         expect_no_tokens(&tokenizer, location);
 
         block_list_push(arena, output, statement);

--- a/src/library/statement.c
+++ b/src/library/statement.c
@@ -24,8 +24,8 @@ void dump_statement(FILE *stream, Statement statement, int level)
     }
     break;
 
-    case STATEMENT_KIND_BIND_LABEL: {
-        String_View name = statement.value.as_bind_label.name;
+    case STATEMENT_KIND_LABEL: {
+        String_View name = statement.value.as_label.name;
 
         fprintf(stream, "%*sLabel:\n", level * 2, "");
         fprintf(stream, "%*s"SV_Fmt"\n", (level + 1) * 2, "", SV_Arg(name));
@@ -168,9 +168,9 @@ int dump_statement_as_dot_edges(FILE *stream, Statement statement, int *counter)
     }
     break;
 
-    case STATEMENT_KIND_BIND_LABEL: {
+    case STATEMENT_KIND_LABEL: {
         int id = (*counter)++;
-        String_View name = statement.value.as_bind_label.name;
+        String_View name = statement.value.as_label.name;
         fprintf(stream, "Expr_%d [shape=diamond label=\"Label: "SV_Fmt"\"]\n",
                 id, SV_Arg(name));
         return id;
@@ -605,7 +605,7 @@ void parse_directive_from_line(Arena *arena, Linizer *linizer, Block_List *outpu
         if (inline_entry) {
             Statement statement = {0};
             statement.location = location;
-            statement.kind = STATEMENT_KIND_BIND_LABEL;
+            statement.kind = STATEMENT_KIND_LABEL;
 
             if (expr.kind != EXPR_KIND_BINDING) {
                 fprintf(stderr, FL_Fmt": ERROR: expected binding name for a label\n",
@@ -613,7 +613,7 @@ void parse_directive_from_line(Arena *arena, Linizer *linizer, Block_List *outpu
                 exit(1);
             }
 
-            statement.value.as_bind_label.name = expr.value.as_binding;
+            statement.value.as_label.name = expr.value.as_binding;
             block_list_push(arena, output, statement);
         }
     } else if (sv_eq(name, SV("error"))) {
@@ -810,8 +810,8 @@ Block_Statement *parse_block_from_lines(Arena *arena, Linizer *linizer)
 
             Statement statement = {0};
             statement.location = location;
-            statement.kind = STATEMENT_KIND_BIND_LABEL;
-            statement.value.as_bind_label.name = label.value.as_binding;
+            statement.kind = STATEMENT_KIND_LABEL;
+            statement.value.as_label.name = label.value.as_binding;
             block_list_push(arena, &result, statement);
 
             linizer_next(linizer, NULL);

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -11,7 +11,7 @@ typedef struct Fundef_Statement Fundef_Statement;
 
 typedef enum {
     STATEMENT_KIND_EMIT_INST,
-    STATEMENT_KIND_BIND_LABEL,
+    STATEMENT_KIND_LABEL,
     STATEMENT_KIND_CONST,
     STATEMENT_KIND_BIND_NATIVE,
     STATEMENT_KIND_INCLUDE,
@@ -34,7 +34,7 @@ typedef struct {
 
 typedef struct {
     String_View name;
-} Bind_Label_Statement;
+} Label_Statement;
 
 typedef struct {
     String_View name;
@@ -95,7 +95,7 @@ typedef struct {
 typedef union {
     Emit_Inst_Statement as_emit_inst;
     // TODO(#327): Remove redundant prefix `bind` from *_Statement types
-    Bind_Label_Statement as_bind_label;
+    Label_Statement as_label;
     Const_Statement as_const;
     Bind_Native_Statement as_bind_native;
     Include_Statement as_include;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -13,7 +13,7 @@ typedef enum {
     STATEMENT_KIND_EMIT_INST,
     STATEMENT_KIND_LABEL,
     STATEMENT_KIND_CONST,
-    STATEMENT_KIND_BIND_NATIVE,
+    STATEMENT_KIND_NATIVE,
     STATEMENT_KIND_INCLUDE,
     STATEMENT_KIND_ASSERT,
     STATEMENT_KIND_ERROR,
@@ -43,7 +43,7 @@ typedef struct {
 
 typedef struct {
     String_View name;
-} Bind_Native_Statement;
+} Native_Statement;
 
 typedef struct {
     String_View path;
@@ -97,7 +97,7 @@ typedef union {
     // TODO(#327): Remove redundant prefix `bind` from *_Statement types
     Label_Statement as_label;
     Const_Statement as_const;
-    Bind_Native_Statement as_bind_native;
+    Native_Statement as_native;
     Include_Statement as_include;
     Assert_Statement as_assert;
     Error_Statement as_error;

--- a/src/library/statement.h
+++ b/src/library/statement.h
@@ -12,7 +12,7 @@ typedef struct Fundef_Statement Fundef_Statement;
 typedef enum {
     STATEMENT_KIND_EMIT_INST,
     STATEMENT_KIND_BIND_LABEL,
-    STATEMENT_KIND_BIND_CONST,
+    STATEMENT_KIND_CONST,
     STATEMENT_KIND_BIND_NATIVE,
     STATEMENT_KIND_INCLUDE,
     STATEMENT_KIND_ASSERT,
@@ -39,7 +39,7 @@ typedef struct {
 typedef struct {
     String_View name;
     Expr value;
-} Bind_Const_Statement;
+} Const_Statement;
 
 typedef struct {
     String_View name;
@@ -96,7 +96,7 @@ typedef union {
     Emit_Inst_Statement as_emit_inst;
     // TODO(#327): Remove redundant prefix `bind` from *_Statement types
     Bind_Label_Statement as_bind_label;
-    Bind_Const_Statement as_bind_const;
+    Const_Statement as_const;
     Bind_Native_Statement as_bind_native;
     Include_Statement as_include;
     Assert_Statement as_assert;


### PR DESCRIPTION
Close #327 

Also removed `Bind` from `dump_statement` function output for `Const` statement:
<details>

<summary>git diff</summary>

```diff
-        fprintf(stream, "%*sBind Const:\n", level * 2, "");
+        fprintf(stream, "%*sConst:\n", level * 2, "");
```

</details