### PR TITLE
Make basm's nasm output format even better than before

### DIFF
--- a/nobuild.c
+++ b/nobuild.c
@@ -295,7 +295,7 @@ void test_command(int argc, char **argv)
             }
         });
     } else {
-        assert(0 && "FIXME: implement some mechanism to test native executables");
+        assert(0 && "TODO: implement some mechanism to test native executables");
     }
 }
 

--- a/nobuild.c
+++ b/nobuild.c
@@ -295,7 +295,7 @@ void test_command(int argc, char **argv)
             }
         });
     } else {
-        assert(0 && "TODO: implement some mechanism to test native executables");
+        assert(0 && "TODO(#348): implement some mechanism to test native executables");
     }
 }
 

--- a/nobuild.c
+++ b/nobuild.c
@@ -257,7 +257,7 @@ void cases_command(int argc, char **argv)
             }
         });
     } else {
-#if defined(__linux__)
+#ifdef __linux__
         FOREACH_FILE_IN_DIR(caze, PATH("test", "cases"), {
             if (ENDS_WITH(caze, ".basm"))
             {

--- a/nobuild.c
+++ b/nobuild.c
@@ -266,8 +266,12 @@ void cases_command(int argc, char **argv)
                     "-f", "nasm",
                     PATH("test", "cases", caze),
                     "-o", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".asm")));
-                CMD("nasm", "-felf64", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".asm")), "-o", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".o")));
-                CMD("ld", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".o")), "-o", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".elf")));
+                CMD("nasm", "-felf64",
+                    PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".asm")),
+                    "-o", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".o")));
+                CMD("ld",
+                    PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".o")),
+                    "-o", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".elf")));
             }
         });
 #else

--- a/nobuild.c
+++ b/nobuild.c
@@ -270,10 +270,10 @@ void cases_command(int argc, char **argv)
                 CMD("ld", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".o")), "-o", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".elf")));
             }
         });
-    }
 #else
     assert(0 && "FIXME: right now assembly that basm produces is linux only");
 #endif
+    }
 }
 
 void test_command(int argc, char **argv)

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1905,7 +1905,6 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov al, BYTE [rsi]\n");
             fprintf(output, "    movsx rax, al\n");
             fprintf(output, "    mov [r11], rax\n");
-            jmp_count += 1;
         }
         break;
         case INST_READ8U: {
@@ -1929,7 +1928,6 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov ax, WORD [rsi]\n");
             fprintf(output, "    movsx rax, ax\n");
             fprintf(output, "    mov [r11], rax\n");
-            jmp_count += 1;
         }
         break;
         case INST_READ16U: {
@@ -1953,7 +1951,6 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov eax, DWORD [rsi]\n");
             fprintf(output, "    movsx rax, eax\n");
             fprintf(output, "    mov [r11], rax\n");
-            jmp_count += 1;
         }
         break;
         case INST_READ32U: {

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1743,18 +1743,82 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             assert(false && "LTF is not implemented");
         case INST_NEF:
             assert(false && "NEF is not implemented");
-        case INST_ANDB:
-            assert(false && "ANDB is not implemented");
-        case INST_ORB:
-            assert(false && "ORB is not implemented");
-        case INST_XOR:
-            assert(false && "XOR is not implemented");
-        case INST_SHR:
-            assert(false && "SHR is not implemented");
-        case INST_SHL:
-            assert(false && "SHL is not implemented");
-        case INST_NOTB:
-            assert(false && "NOTB is not implemented");
+        case INST_ANDB: {
+            fprintf(output, "    ;; andb\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rax, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rbx, [rsi]\n");
+            fprintf(output, "    and rax, rbx\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_ORB: {
+            fprintf(output, "    ;; orb\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rax, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rbx, [rsi]\n");
+            fprintf(output, "    or rax, rbx\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_XOR: {
+            fprintf(output, "    ;; xor\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rax, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rbx, [rsi]\n");
+            fprintf(output, "    xor rax, rbx\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_SHR: {
+            fprintf(output, "    ;; shr\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rcx, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rax, [rsi]\n");
+            fprintf(output, "    shr rax, cl\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_SHL: {
+            fprintf(output, "    ;; shl\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rcx, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rax, [rsi]\n");
+            fprintf(output, "    shl rax, cl\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_NOTB: {
+            fprintf(output, "    ;; notb\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rax, [rsi]\n");
+            fprintf(output, "    not rax\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
         case INST_READ8I:
             assert(false && "READ8I is not implemented");
         case INST_READ16I:

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -2072,7 +2072,7 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov [stack_top], r11\n");
         }
         break;
-        // TODO: try to get rid of branching in f2u implementation of basm_save_to_file_as_nasm()
+        // TODO(#349): try to get rid of branching in f2u implementation of basm_save_to_file_as_nasm()
         case INST_F2U: {
             fprintf(output, "    ;; f2i\n");
             fprintf(output, "    mov r11, [stack_top]\n");

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1903,11 +1903,7 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    add rsi, memory\n");
             fprintf(output, "    xor rax, rax\n");
             fprintf(output, "    mov al, BYTE [rsi]\n");
-            fprintf(output, "    test al, al\n");
-            fprintf(output, "    jnl .read8i_%zu\n", jmp_count);
-            fprintf(output, "    neg al\n");
-            fprintf(output, "    neg rax\n");
-            fprintf(output, "    .read8i_%zu:\n", jmp_count);
+            fprintf(output, "    movsx rax, al\n");
             fprintf(output, "    mov [r11], rax\n");
             jmp_count += 1;
         }
@@ -1931,11 +1927,7 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    add rsi, memory\n");
             fprintf(output, "    xor rax, rax\n");
             fprintf(output, "    mov ax, WORD [rsi]\n");
-            fprintf(output, "    test ax, ax\n");
-            fprintf(output, "    jnl .read16i_%zu\n", jmp_count);
-            fprintf(output, "    neg ax\n");
-            fprintf(output, "    neg rax\n");
-            fprintf(output, "    .read16i_%zu:\n", jmp_count);
+            fprintf(output, "    movsx rax, ax\n");
             fprintf(output, "    mov [r11], rax\n");
             jmp_count += 1;
         }
@@ -1959,11 +1951,7 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    add rsi, memory\n");
             fprintf(output, "    xor rax, rax\n");
             fprintf(output, "    mov eax, DWORD [rsi]\n");
-            fprintf(output, "    test eax, eax\n");
-            fprintf(output, "    jnl .read32i_%zu\n", jmp_count);
-            fprintf(output, "    neg eax\n");
-            fprintf(output, "    neg rax\n");
-            fprintf(output, "    .read32i_%zu:\n", jmp_count);
+            fprintf(output, "    movsx rax, eax\n");
             fprintf(output, "    mov [r11], rax\n");
             jmp_count += 1;
         }

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1896,13 +1896,6 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
         }
         break;
         case INST_READ8I:
-            assert(false && "READ8I is not implemented");
-        case INST_READ16I:
-            assert(false && "READ16I is not implemented");
-        case INST_READ32I:
-            assert(false && "READ32I is not implemented");
-        case INST_READ64I:
-            assert(false && "READ64I is not implemented");
         case INST_READ8U: {
             fprintf(output, "    ;; read8\n");
             fprintf(output, "    mov r11, [stack_top]\n");
@@ -1914,12 +1907,42 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov [r11], rax\n");
         }
         break;
-        case INST_READ16U:
-            assert(false && "READ16 is not implemented");
-        case INST_READ32U:
-            assert(false && "READ32 is not implemented");
-        case INST_READ64U:
-            assert(false && "READ64 is not implemented");
+        case INST_READ16I:
+        case INST_READ16U: {
+            fprintf(output, "    ;; read16\n");
+            fprintf(output, "    mov r11, [stack_top]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rsi, [r11]\n");
+            fprintf(output, "    add rsi, memory\n");
+            fprintf(output, "    xor rax, rax\n");
+            fprintf(output, "    mov ax, WORD [rsi]\n");
+            fprintf(output, "    mov [r11], rax\n");
+        }
+        break;
+        case INST_READ32I:
+        case INST_READ32U: {
+            fprintf(output, "    ;; read32\n");
+            fprintf(output, "    mov r11, [stack_top]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rsi, [r11]\n");
+            fprintf(output, "    add rsi, memory\n");
+            fprintf(output, "    xor rax, rax\n");
+            fprintf(output, "    mov eax, DWORD [rsi]\n");
+            fprintf(output, "    mov [r11], rax\n");
+        }
+        break;
+        case INST_READ64I:
+        case INST_READ64U: {
+            fprintf(output, "    ;; read64\n");
+            fprintf(output, "    mov r11, [stack_top]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rsi, [r11]\n");
+            fprintf(output, "    add rsi, memory\n");
+            fprintf(output, "    xor rax, rax\n");
+            fprintf(output, "    mov rax, QWORD [rsi]\n");
+            fprintf(output, "    mov [r11], rax\n");
+        }
+        break;
         case INST_WRITE8: {
             fprintf(output, "    ;; write8\n");
             fprintf(output, "    mov r11, [stack_top]\n");

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1274,7 +1274,7 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
     fprintf(output, "segment .text\n");
     fprintf(output, "global _start\n");
 
-    size_t jmp_if_escape_count = 0;
+    size_t jmp_count = 0;
     for (size_t i = 0; i < basm->program_size; ++i) {
         Inst inst = basm->program[i];
 
@@ -1495,12 +1495,12 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov rax, [rsi]\n");
             fprintf(output, "    mov [stack_top], rsi\n");
             fprintf(output, "    cmp rax, 0\n");
-            fprintf(output, "    je jmp_if_escape_%zu\n", jmp_if_escape_count);
+            fprintf(output, "    je jmp_if_escape_%zu\n", jmp_count);
             fprintf(output, "    mov rdi, inst_map\n");
             fprintf(output, "    add rdi, BM_WORD_SIZE * %"PRIu64"\n", inst.operand.as_u64);
             fprintf(output, "    jmp [rdi]\n");
-            fprintf(output, "jmp_if_escape_%zu:\n", jmp_if_escape_count);
-            jmp_if_escape_count += 1;
+            fprintf(output, "jmp_if_escape_%zu:\n", jmp_count);
+            jmp_count += 1;
         }
         break;
         case INST_RET: {
@@ -1904,12 +1904,12 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    xor rax, rax\n");
             fprintf(output, "    mov al, BYTE [rsi]\n");
             fprintf(output, "    test al, al\n");
-            fprintf(output, "    jnl .read8i_%zu\n", jmp_if_escape_count);
+            fprintf(output, "    jnl .read8i_%zu\n", jmp_count);
             fprintf(output, "    neg al\n");
             fprintf(output, "    neg rax\n");
-            fprintf(output, "    .read8i_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    .read8i_%zu:\n", jmp_count);
             fprintf(output, "    mov [r11], rax\n");
-            jmp_if_escape_count += 1;
+            jmp_count += 1;
         }
         break;
         case INST_READ8U: {
@@ -1932,12 +1932,12 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    xor rax, rax\n");
             fprintf(output, "    mov ax, WORD [rsi]\n");
             fprintf(output, "    test ax, ax\n");
-            fprintf(output, "    jnl .read16i_%zu\n", jmp_if_escape_count);
+            fprintf(output, "    jnl .read16i_%zu\n", jmp_count);
             fprintf(output, "    neg ax\n");
             fprintf(output, "    neg rax\n");
-            fprintf(output, "    .read16i_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    .read16i_%zu:\n", jmp_count);
             fprintf(output, "    mov [r11], rax\n");
-            jmp_if_escape_count += 1;
+            jmp_count += 1;
         }
         break;
         case INST_READ16U: {
@@ -1960,12 +1960,12 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    xor rax, rax\n");
             fprintf(output, "    mov eax, DWORD [rsi]\n");
             fprintf(output, "    test eax, eax\n");
-            fprintf(output, "    jnl .read32i_%zu\n", jmp_if_escape_count);
+            fprintf(output, "    jnl .read32i_%zu\n", jmp_count);
             fprintf(output, "    neg eax\n");
             fprintf(output, "    neg rax\n");
-            fprintf(output, "    .read32i_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    .read32i_%zu:\n", jmp_count);
             fprintf(output, "    mov [r11], rax\n");
-            jmp_if_escape_count += 1;
+            jmp_count += 1;
         }
         break;
         case INST_READ32U: {
@@ -2057,11 +2057,11 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    sub r11, BM_WORD_SIZE\n");
             fprintf(output, "    mov rdi, [r11]\n");
             fprintf(output, "    test rdi, rdi\n");
-            fprintf(output, "    js .u2f_%zu\n", jmp_if_escape_count);
+            fprintf(output, "    js .u2f_%zu\n", jmp_count);
             fprintf(output, "    pxor xmm0, xmm0\n");
             fprintf(output, "    cvtsi2sd xmm0, rdi\n");
-            fprintf(output, "    jmp .u2f_end_%zu\n", jmp_if_escape_count);
-            fprintf(output, "    .u2f_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    jmp .u2f_end_%zu\n", jmp_count);
+            fprintf(output, "    .u2f_%zu:\n", jmp_count);
             fprintf(output, "    mov rax, rdi\n");
             fprintf(output, "    and edi, 1\n");
             fprintf(output, "    pxor xmm0, xmm0\n");
@@ -2069,11 +2069,11 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    or rax, rdi\n");
             fprintf(output, "    cvtsi2sd xmm0, rax\n");
             fprintf(output, "    addsd xmm0, xmm0\n");
-            fprintf(output, "    .u2f_end_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    .u2f_end_%zu:\n", jmp_count);
             fprintf(output, "    movsd [r11], xmm0\n");
             fprintf(output, "    add r11, BM_WORD_SIZE\n");
             fprintf(output, "    mov [stack_top], r11\n");
-            jmp_if_escape_count += 1;
+            jmp_count += 1;
         }
         break;
         case INST_F2I: {
@@ -2094,14 +2094,14 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    movsd xmm0, [r11]\n");
             fprintf(output, "    movsd xmm1, [magic_number_for_f2u]\n");
             fprintf(output, "    comisd xmm0, xmm1\n");
-            fprintf(output, "    jnb .f2u_%zu\n", jmp_if_escape_count);
+            fprintf(output, "    jnb .f2u_%zu\n", jmp_count);
             fprintf(output, "    cvttsd2si rax, xmm0\n");
-            fprintf(output, "    jmp .f2u_end_%zu\n", jmp_if_escape_count);
-            fprintf(output, "    .f2u_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    jmp .f2u_end_%zu\n", jmp_count);
+            fprintf(output, "    .f2u_%zu:\n", jmp_count);
             fprintf(output, "    subsd xmm0, xmm1\n");
             fprintf(output, "    cvttsd2si rax, xmm0\n");
             fprintf(output, "    btc rax, 63\n");
-            fprintf(output, "    .f2u_end_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    .f2u_end_%zu:\n", jmp_count);
             fprintf(output, "    mov [r11], rax\n");
             fprintf(output, "    add r11, BM_WORD_SIZE\n");
             fprintf(output, "    mov [stack_top], r11\n");

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1284,8 +1284,11 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
 
         fprintf(output, "inst_%zu:\n", i);
         switch (inst.type) {
-        case INST_NOP:
-            assert(false && "NOP is not implemented");
+        case INST_NOP: {
+            fprintf(output, "    ;; nop\n");
+            fprintf(output, "    nop\n");
+        }
+        break;
         case INST_PUSH: {
             fprintf(output, "    ;; push %"PRIu64"\n", inst.operand.as_u64);
             fprintf(output, "    mov rsi, [stack_top]\n");

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1955,12 +1955,6 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov [stack_top], r11\n");
         }
         break;
-        case INST_WRITE16:
-            assert(false && "WRITE16 is not implemented");
-        case INST_WRITE32:
-            assert(false && "WRITE32 is not implemented");
-        case INST_WRITE64:
-            assert(false && "WRITE64 is not implemented");
         case INST_I2F:
             assert(false && "I2F is not implemented");
         case INST_U2F:
@@ -1969,6 +1963,42 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             assert(false && "F2I is not implemented");
         case INST_F2U:
             assert(false && "F2U is not implemented");
+        case INST_WRITE16: {
+            fprintf(output, "    ;; write16\n");
+            fprintf(output, "    mov r11, [stack_top]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rax, [r11]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rsi, [r11]\n");
+            fprintf(output, "    add rsi, memory\n");
+            fprintf(output, "    mov WORD [rsi], ax\n");
+            fprintf(output, "    mov [stack_top], r11\n");
+        }
+        break;
+        case INST_WRITE32: {
+            fprintf(output, "    ;; write32\n");
+            fprintf(output, "    mov r11, [stack_top]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rax, [r11]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rsi, [r11]\n");
+            fprintf(output, "    add rsi, memory\n");
+            fprintf(output, "    mov DWORD [rsi], eax\n");
+            fprintf(output, "    mov [stack_top], r11\n");
+        }
+        break;
+        case INST_WRITE64: {
+            fprintf(output, "    ;; write64\n");
+            fprintf(output, "    mov r11, [stack_top]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rax, [r11]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rsi, [r11]\n");
+            fprintf(output, "    add rsi, memory\n");
+            fprintf(output, "    mov QWORD [rsi], rax\n");
+            fprintf(output, "    mov [stack_top], r11\n");
+        }
+        break;
         case NUMBER_OF_INSTS:
         default:
             assert(false && "unknown instruction");

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1895,7 +1895,23 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov [stack_top], rsi\n");
         }
         break;
-        case INST_READ8I:
+        case INST_READ8I: {
+            fprintf(output, "    ;; read8i\n");
+            fprintf(output, "    mov r11, [stack_top]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rsi, [r11]\n");
+            fprintf(output, "    add rsi, memory\n");
+            fprintf(output, "    xor rax, rax\n");
+            fprintf(output, "    mov al, BYTE [rsi]\n");
+            fprintf(output, "    test al, al\n");
+            fprintf(output, "    jnl .read8i_%zu\n", jmp_if_escape_count);
+            fprintf(output, "    neg al\n");
+            fprintf(output, "    neg rax\n");
+            fprintf(output, "    .read8i_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    mov [r11], rax\n");
+            jmp_if_escape_count += 1;
+        }
+        break;
         case INST_READ8U: {
             fprintf(output, "    ;; read8\n");
             fprintf(output, "    mov r11, [stack_top]\n");
@@ -1907,9 +1923,25 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov [r11], rax\n");
         }
         break;
-        case INST_READ16I:
+        case INST_READ16I: {
+            fprintf(output, "    ;; read16i\n");
+            fprintf(output, "    mov r11, [stack_top]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rsi, [r11]\n");
+            fprintf(output, "    add rsi, memory\n");
+            fprintf(output, "    xor rax, rax\n");
+            fprintf(output, "    mov ax, WORD [rsi]\n");
+            fprintf(output, "    test ax, ax\n");
+            fprintf(output, "    jnl .read16i_%zu\n", jmp_if_escape_count);
+            fprintf(output, "    neg ax\n");
+            fprintf(output, "    neg rax\n");
+            fprintf(output, "    .read16i_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    mov [r11], rax\n");
+            jmp_if_escape_count += 1;
+        }
+        break;
         case INST_READ16U: {
-            fprintf(output, "    ;; read16\n");
+            fprintf(output, "    ;; read16u\n");
             fprintf(output, "    mov r11, [stack_top]\n");
             fprintf(output, "    sub r11, BM_WORD_SIZE\n");
             fprintf(output, "    mov rsi, [r11]\n");
@@ -1919,9 +1951,25 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov [r11], rax\n");
         }
         break;
-        case INST_READ32I:
+        case INST_READ32I: {
+            fprintf(output, "    ;; read32i\n");
+            fprintf(output, "    mov r11, [stack_top]\n");
+            fprintf(output, "    sub r11, BM_WORD_SIZE\n");
+            fprintf(output, "    mov rsi, [r11]\n");
+            fprintf(output, "    add rsi, memory\n");
+            fprintf(output, "    xor rax, rax\n");
+            fprintf(output, "    mov eax, DWORD [rsi]\n");
+            fprintf(output, "    test eax, eax\n");
+            fprintf(output, "    jnl .read32i_%zu\n", jmp_if_escape_count);
+            fprintf(output, "    neg eax\n");
+            fprintf(output, "    neg rax\n");
+            fprintf(output, "    .read32i_%zu:\n", jmp_if_escape_count);
+            fprintf(output, "    mov [r11], rax\n");
+            jmp_if_escape_count += 1;
+        }
+        break;
         case INST_READ32U: {
-            fprintf(output, "    ;; read32\n");
+            fprintf(output, "    ;; read32u\n");
             fprintf(output, "    mov r11, [stack_top]\n");
             fprintf(output, "    sub r11, BM_WORD_SIZE\n");
             fprintf(output, "    mov rsi, [r11]\n");

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1731,18 +1731,94 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov [stack_top], rsi\n");
         }
         break;
-        case INST_EQF:
-            assert(false && "EQF is not implemented");
-        case INST_GEF:
-            assert(false && "GEF is not implemented");
-        case INST_GTF:
-            assert(false && "GTF is not implemented");
-        case INST_LEF:
-            assert(false && "LEF is not implemented");
-        case INST_LTF:
-            assert(false && "LTF is not implemented");
-        case INST_NEF:
-            assert(false && "NEF is not implemented");
+        case INST_EQF: {
+            fprintf(output, "    ;; eqf\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm0, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm1, [rsi]\n");
+            fprintf(output, "    ucomisd xmm0, xmm1\n");
+            fprintf(output, "    mov edx, 0\n");
+            fprintf(output, "    setnp al\n");
+            fprintf(output, "    cmovne eax, edx\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_GEF: {
+            fprintf(output, "    ;; gef\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm0, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm1, [rsi]\n");
+            fprintf(output, "    comisd xmm1, xmm0\n");
+            fprintf(output, "    setae al\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_GTF: {
+            fprintf(output, "    ;; gtf\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm0, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm1, [rsi]\n");
+            fprintf(output, "    comisd xmm1, xmm0\n");
+            fprintf(output, "    seta al\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_LEF: {
+            fprintf(output, "    ;; lef\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm0, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm1, [rsi]\n");
+            fprintf(output, "    comisd xmm0, xmm1\n");
+            fprintf(output, "    setnb al\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_LTF: {
+            fprintf(output, "    ;; ltf\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm0, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm1, [rsi]\n");
+            fprintf(output, "    comisd xmm0, xmm1\n");
+            fprintf(output, "    seta al\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
+        case INST_NEF: {
+            fprintf(output, "    ;; ltf\n");
+            fprintf(output, "    mov rsi, [stack_top]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm0, [rsi]\n");
+            fprintf(output, "    sub rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    movsd xmm1, [rsi]\n");
+            fprintf(output, "    ucomisd xmm1, xmm0\n");
+            fprintf(output, "    mov edx, 1\n");
+            fprintf(output, "    setp al\n");
+            fprintf(output, "    cmovne eax, edx\n");
+            fprintf(output, "    mov [rsi], rax\n");
+            fprintf(output, "    add rsi, BM_WORD_SIZE\n");
+            fprintf(output, "    mov [stack_top], rsi\n");
+        }
+        break;
         case INST_ANDB: {
             fprintf(output, "    ;; andb\n");
             fprintf(output, "    mov rsi, [stack_top]\n");

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -2072,6 +2072,7 @@ void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
             fprintf(output, "    mov [stack_top], r11\n");
         }
         break;
+        // TODO: try to get rid of branching in f2u implementation of basm_save_to_file_as_nasm()
         case INST_F2U: {
             fprintf(output, "    ;; f2i\n");
             fprintf(output, "    mov r11, [stack_top]\n");


### PR DESCRIPTION
All basm instructions are now implemented in nasm HYPERS

Tests can be now compiled to native executables via `./nobuild cases nasm`

When `nobuild` is compiled not for linux it will fail with assert on attempt to compile tests via nasm.
`./nobuild test nasm` will also fail with assert, because there is no mechanism to capture and check output of tests build with nasm yet