### PR TITLE
Rename `basm -f nasm` to `basm -f nasm-linux-x86-64`

### DIFF
--- a/nobuild.c
+++ b/nobuild.c
@@ -272,7 +272,7 @@ void cases_command(int argc, char **argv)
             {
                 CMD(PATH("build", "toolchain", "basm"),
                     "-I", "./lib/",
-                    "-f", "nasm",
+                    "-f", "nasm-linux-x86-64",
                     PATH("test", "cases", caze),
                     "-o", PATH("build", "test", "cases", CONCAT(NOEXT(caze), ".asm")));
                 CMD("nasm", "-felf64",

--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1246,7 +1246,7 @@ Macrodef *basm_resolve_macrodef(Basm *basm, String_View name)
     return NULL;
 }
 
-void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path)
+void basm_save_to_file_as_nasm_linux_x86_64(Basm *basm, const char *output_file_path)
 {
     FILE *output = fopen(output_file_path, "wb");
     if (output == NULL) {

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -153,7 +153,7 @@ void basm_bind_expr(Basm *basm, String_View name, Expr expr, File_Location locat
 void basm_bind_value(Basm *basm, String_View name, Word value, Type type, File_Location location);
 void basm_push_deferred_operand(Basm *basm, Inst_Addr addr, Expr expr, File_Location location);
 void basm_save_to_file_as_bm(Basm *basm, const char *output_file_path);
-void basm_save_to_file_as_nasm(Basm *basm, const char *output_file_path);
+void basm_save_to_file_as_nasm_linux_x86_64(Basm *basm, const char *output_file_path);
 Word basm_push_string_to_memory(Basm *basm, String_View sv);
 Word basm_push_byte_array_to_memory(Basm *basm, uint64_t size, uint8_t value);
 Word basm_push_buffer_to_memory(Basm *basm, uint8_t *buffer, uint64_t buffer_size);

--- a/src/toolchain/basm.c
+++ b/src/toolchain/basm.c
@@ -5,7 +5,7 @@
 
 typedef enum {
     BASM_OUTPUT_BM = 0,
-    BASM_OUTPUT_NASM,
+    BASM_OUTPUT_NASM_LINUX_X86_64,
     COUNT_BASM_OUTPUTS
 } Basm_Output_Format;
 
@@ -14,7 +14,7 @@ static String_View output_format_file_ext(Basm_Output_Format format)
     switch (format) {
     case BASM_OUTPUT_BM:
         return SV(".bm");
-    case BASM_OUTPUT_NASM:
+    case BASM_OUTPUT_NASM_LINUX_X86_64:
         return SV(".asm");
     case COUNT_BASM_OUTPUTS:
     default:
@@ -32,8 +32,8 @@ static bool output_format_by_name(const char *name, Basm_Output_Format *format)
     if (strcmp(name, "bm") == 0) {
         *format = BASM_OUTPUT_BM;
         return true;
-    } else if (strcmp(name, "nasm") == 0) {
-        *format = BASM_OUTPUT_NASM;
+    } else if (strcmp(name, "nasm-linux-x86-64") == 0) {
+        *format = BASM_OUTPUT_NASM_LINUX_X86_64;
         return true;
     } else {
         return false;
@@ -53,11 +53,11 @@ static void usage(FILE *stream, const char *program)
 {
     fprintf(stream, "Usage: %s [OPTIONS] <input.basm>\n", program);
     fprintf(stream, "OPTIONS:\n");
-    fprintf(stream, "    -I <include/path/>    Add include path\n");
-    fprintf(stream, "    -o <output.bm>        Provide output path\n");
-    fprintf(stream, "    -f <bm|nasm>          Output format. Default is bm\n");
-    fprintf(stream, "    -verify               Verify the bytecode instructions after the translation\n");
-    fprintf(stream, "    -h                    Print this help to stdout\n");
+    fprintf(stream, "    -I <include/path/>        Add include path\n");
+    fprintf(stream, "    -o <output.bm>            Provide output path\n");
+    fprintf(stream, "    -f <bm|nasm-linux-x86-64> Output format. Default is bm\n");
+    fprintf(stream, "    -verify                   Verify the bytecode instructions after the translation\n");
+    fprintf(stream, "    -h                        Print this help to stdout\n");
 }
 
 static char *get_flag_value(int *argc, char ***argv,
@@ -141,8 +141,8 @@ int main(int argc, char **argv)
     }
     break;
 
-    case BASM_OUTPUT_NASM: {
-        basm_save_to_file_as_nasm(&basm, output_file_path);
+    case BASM_OUTPUT_NASM_LINUX_X86_64: {
+        basm_save_to_file_as_nasm_linux_x86_64(&basm, output_file_path);
     }
     break;
 


### PR DESCRIPTION
Since the code it generates works only Linux x86_64. So I decided to
emphasize that with the name.