### PR TITLE
Add FreeBSD target for Native Codegen via NASM

### DIFF
--- a/src/library/basm.c
+++ b/src/library/basm.c
@@ -1246,7 +1246,7 @@ Macrodef *basm_resolve_macrodef(Basm *basm, String_View name)
     return NULL;
 }
 
-void basm_save_to_file_as_nasm_linux_x86_64(Basm *basm, const char *output_file_path)
+void basm_save_to_file_as_nasm_sysv_x86_64(Basm *basm, Syscall_Target target, const char *output_file_path)
 {
     FILE *output = fopen(output_file_path, "wb");
     if (output == NULL) {
@@ -1258,8 +1258,18 @@ void basm_save_to_file_as_nasm_linux_x86_64(Basm *basm, const char *output_file_
     fprintf(output, "BITS 64\n");
     fprintf(output, "%%define BM_STACK_CAPACITY %d\n", BM_STACK_CAPACITY);
     fprintf(output, "%%define BM_WORD_SIZE %d\n", BM_WORD_SIZE);
-    fprintf(output, "%%define SYS_EXIT 60\n");
-    fprintf(output, "%%define SYS_WRITE 1\n");
+
+    switch (target) {
+    case SYSCALLTARGET_LINUX: {
+        fprintf(output, "%%define SYS_EXIT 60\n");
+        fprintf(output, "%%define SYS_WRITE 1\n");
+    } break;
+    case SYSCALLTARGET_FREEBSD: {
+        fprintf(output, "%%define SYS_EXIT 1\n");
+        fprintf(output, "%%define SYS_WRITE 4\n");
+    } break;
+    }
+
     fprintf(output, "%%define STDOUT 1\n");
     fprintf(output, "segment .text\n");
     fprintf(output, "global _start\n");

--- a/src/library/basm.h
+++ b/src/library/basm.h
@@ -17,6 +17,11 @@
 #define BASM_INCLUDE_PATHS_CAPACITY 1024
 
 typedef enum {
+    SYSCALLTARGET_LINUX = 0,
+    SYSCALLTARGET_FREEBSD
+} Syscall_Target;
+
+typedef enum {
     BINDING_UNEVALUATED = 0,
     BINDING_EVALUATING,
     BINDING_EVALUATED,
@@ -153,7 +158,7 @@ void basm_bind_expr(Basm *basm, String_View name, Expr expr, File_Location locat
 void basm_bind_value(Basm *basm, String_View name, Word value, Type type, File_Location location);
 void basm_push_deferred_operand(Basm *basm, Inst_Addr addr, Expr expr, File_Location location);
 void basm_save_to_file_as_bm(Basm *basm, const char *output_file_path);
-void basm_save_to_file_as_nasm_linux_x86_64(Basm *basm, const char *output_file_path);
+void basm_save_to_file_as_nasm_sysv_x86_64(Basm *basm, Syscall_Target target, const char *output_file_path);
 Word basm_push_string_to_memory(Basm *basm, String_View sv);
 Word basm_push_byte_array_to_memory(Basm *basm, uint64_t size, uint8_t value);
 Word basm_push_buffer_to_memory(Basm *basm, uint8_t *buffer, uint64_t buffer_size);

--- a/src/toolchain/basm.c
+++ b/src/toolchain/basm.c
@@ -6,6 +6,7 @@
 typedef enum {
     BASM_OUTPUT_BM = 0,
     BASM_OUTPUT_NASM_LINUX_X86_64,
+    BASM_OUTPUT_NASM_FREEBSD_X86_64,
     COUNT_BASM_OUTPUTS
 } Basm_Output_Format;
 
@@ -16,6 +17,8 @@ static String_View output_format_file_ext(Basm_Output_Format format)
         return SV(".bm");
     case BASM_OUTPUT_NASM_LINUX_X86_64:
         return SV(".asm");
+    case BASM_OUTPUT_NASM_FREEBSD_X86_64:
+        return SV(".S");
     case COUNT_BASM_OUTPUTS:
     default:
         assert(false && "output_format_file_ext: unreachable");
@@ -26,7 +29,7 @@ static String_View output_format_file_ext(Basm_Output_Format format)
 static bool output_format_by_name(const char *name, Basm_Output_Format *format)
 {
     static_assert(
-        COUNT_BASM_OUTPUTS == 2,
+        COUNT_BASM_OUTPUTS == 3,
         "Please add a condition branch for a new output "
         "and increment the counter above");
     if (strcmp(name, "bm") == 0) {
@@ -34,6 +37,9 @@ static bool output_format_by_name(const char *name, Basm_Output_Format *format)
         return true;
     } else if (strcmp(name, "nasm-linux-x86-64") == 0) {
         *format = BASM_OUTPUT_NASM_LINUX_X86_64;
+        return true;
+    } else if (strcmp(name, "nasm-freebsd-x86-64") == 0) {
+        *format = BASM_OUTPUT_NASM_FREEBSD_X86_64;
         return true;
     } else {
         return false;
@@ -53,11 +59,11 @@ static void usage(FILE *stream, const char *program)
 {
     fprintf(stream, "Usage: %s [OPTIONS] <input.basm>\n", program);
     fprintf(stream, "OPTIONS:\n");
-    fprintf(stream, "    -I <include/path/>        Add include path\n");
-    fprintf(stream, "    -o <output.bm>            Provide output path\n");
-    fprintf(stream, "    -f <bm|nasm-linux-x86-64> Output format. Default is bm\n");
-    fprintf(stream, "    -verify                   Verify the bytecode instructions after the translation\n");
-    fprintf(stream, "    -h                        Print this help to stdout\n");
+    fprintf(stream, "    -I <include/path/>                            Add include path\n");
+    fprintf(stream, "    -o <output.bm>                                Provide output path\n");
+    fprintf(stream, "    -f <bm|nasm-linux-x86-64|nasm-freebsd-x86-64> Output format. Default is bm\n");
+    fprintf(stream, "    -verify                                       Verify the bytecode instructions after the translation\n");
+    fprintf(stream, "    -h                                            Print this help to stdout\n");
 }
 
 static char *get_flag_value(int *argc, char ***argv,
@@ -142,7 +148,12 @@ int main(int argc, char **argv)
     break;
 
     case BASM_OUTPUT_NASM_LINUX_X86_64: {
-        basm_save_to_file_as_nasm_linux_x86_64(&basm, output_file_path);
+        basm_save_to_file_as_nasm_sysv_x86_64(&basm, SYSCALLTARGET_LINUX, output_file_path);
+    }
+    break;
+
+    case BASM_OUTPUT_NASM_FREEBSD_X86_64: {
+        basm_save_to_file_as_nasm_sysv_x86_64(&basm, SYSCALLTARGET_FREEBSD, output_file_path);
     }
     break;
 


### PR DESCRIPTION
Adapts syscall-IDs for FreeBSD so we don't have to use `brandelf'.

I renamed `basm_save_to_file_as_nasm_linux_x86_64' to
`basm_save_to_file_as_nasm_sysv_x86_64' since effectively we're using
the SystemV AMD64 calling convention here. The only thing that
differs are the syscall ids, which is the additional argument, that
the function now takes.

Also, I'm not quite sure about the type name `Syscall_Target' so if
anyone has got a better name: go ahead!