### PR TITLE
Fix unaligned memory access in emulator

### DIFF
--- a/src/library/gas_arm64.c
+++ b/src/library/gas_arm64.c
@@ -116,8 +116,8 @@ void basm_save_to_file_as_gas_arm64(Basm *basm, Syscall_Target target, const cha
         case INST_SWAP: {
             fprintf(output, "    // swap %"PRIu64"\n", inst.operand.as_u64);
             fprintf(output, "    ldr x9, [x0, #-BM_WORD_SIZE]!\n");
-            fprintf(output, "    ldr x10, [x0, #-%zu]!         // = %zu * BM_WORD_SIZE\n", inst.operand.as_u64 * BM_WORD_SIZE, inst.operand.as_u64);
-            fprintf(output, "    str x9, [x0], #%zu            // as previous\n", inst.operand.as_u64 * BM_WORD_SIZE);
+            fprintf(output, "    ldr x10, [x0, #-%"PRIu64"]!         // = %"PRIu64" * BM_WORD_SIZE\n", inst.operand.as_u64 * BM_WORD_SIZE, inst.operand.as_u64);
+            fprintf(output, "    str x9, [x0], #%"PRIu64"            // as previous\n", inst.operand.as_u64 * BM_WORD_SIZE);
             fprintf(output, "    str x10, [x0], #BM_WORD_SIZE\n");
         }
         break;


### PR DESCRIPTION
Together with #380 and #381, this makes bm/basm work on SPARC and Solaris (10).