### PR TITLE
arm64 : Remove awkward jump table

### DIFF
--- a/src/library/gas_arm64.c
+++ b/src/library/gas_arm64.c
@@ -38,6 +38,7 @@
         fprintf(output, "    cset x1, "cc"\n");                     \
         fprintf(output, "    str x1, [x0], #BM_WORD_SIZE\n");       \
     } while(0)
+
 #define CMP_INT(cc)                                                       \
     do {                                                                \
         fprintf(output, "    ldr x9, [x0, #-BM_WORD_SIZE]!\n");         \

--- a/src/library/gas_arm64.c
+++ b/src/library/gas_arm64.c
@@ -227,19 +227,15 @@ void basm_save_to_file_as_gas_arm64(Basm *basm, OS_Target os_target, const char 
         break;
         case INST_RET: {
             fprintf(output, "    // ret\n");
-            fprintf(output, "    ldr x9, [x0, #-BM_WORD_SIZE]!\n");
-            fprintf(output, "    mov x10, #BM_WORD_SIZE\n");
-            fprintf(output, "    ldr x11, =inst_map\n");
-            fprintf(output, "    madd x12, x9, x10, x11\n");
-            fprintf(output, "    ldr x10, [x12]\n");
-            fprintf(output, "    br x10\n");
+            fprintf(output, "    mov x9, lr\n");
+            fprintf(output, "    ldr lr, [x0, #-BM_WORD_SIZE]!\n");
+            fprintf(output, "    ret x9\n");
         }
         break;
         case INST_CALL: {
             fprintf(output, "    // call\n");
-            fprintf(output, "    mov x9, #%zu\n", i + 1);
-            fprintf(output, "    str x9, [x0], #BM_WORD_SIZE\n");
-            fprintf(output, "    b inst_%"PRIu64"\n", inst.operand.as_u64);
+            fprintf(output, "    str lr, [x0], #BM_WORD_SIZE\n");
+            fprintf(output, "    bl inst_%"PRIu64"\n", inst.operand.as_u64);
         }
         break;
         case INST_NATIVE: {
@@ -540,11 +536,6 @@ void basm_save_to_file_as_gas_arm64(Basm *basm, OS_Target os_target, const char 
     }
 
     fprintf(output, "    .data\n");
-    fprintf(output, "inst_map:\n");
-    for (size_t i = 0; i < basm->program_size; ++i) {
-        fprintf(output, "    .dc.a inst_%zu\n", i);
-    }
-
     fprintf(output, "stack_top: .word stack\n");
 
     fprintf(output, "memory:\n");


### PR DESCRIPTION
As noted in the commit message of 07eef8b .

I removed the jump table because it seemed like a hack anyways. Now we
use the proper call/return mechanisms of arm slightly modified to use
the bm stack instead of the "C stack" (which doesn't really exist
since we don't depend on libc).

Maybe this can be done to the amd64 assembly generator as well.

Spoiler: Performance slightly increased:

## Before
``` console
[nico@henricus ~/src/bm]$ build/toolchain/basm -t gas-freebsd-arm64 -I lib test/cases/pi.basm
[nico@henricus ~/src/bm]$ cc -c -g -o pi.o pi.S
[nico@henricus ~/src/bm]$ ld -o pi pi.o
[nico@henricus ~/src/bm]$ time ./pi
3.1415933203

real   0.273605
user   0.273777
sys    0.000000
[nico@henricus ~/src/bm]$ time ./pi
3.1415933203

real   0.273515
user   0.273590
sys    0.000243
[nico@henricus ~/src/bm]$
```

## After

``` console
[nico@henricus ~/src/bm]$ build/toolchain/basm -t gas-freebsd-arm64 -I lib test/cases/pi.basm
[nico@henricus ~/src/bm]$ cc -c -g -o pi.o pi.S
[nico@henricus ~/src/bm]$ ld -o pi pi.o
[nico@henricus ~/src/bm]$ time ./pi
3.1415933203

real   0.269791
user   0.269187
sys    0.000537
[nico@henricus ~/src/bm]$ time ./pi
3.1415933203

real   0.269755
user   0.262562
sys    0.007125
[nico@henricus ~/src/bm]$
```