### PR TITLE
Fix broken nobuild on FreeBSD 

### DIFF
--- a/nobuild.c
+++ b/nobuild.c
@@ -326,8 +326,6 @@ void cases_command(int argc, char **argv)
         });
 #else
 
-
-// TODO: build asm test cases for FreeBSD
 #if defined(__linux__)
     #define USE_NASM            1
     #define NATIVE_TARGET       "nasm-linux-x86-64"

--- a/nobuild.c
+++ b/nobuild.c
@@ -282,7 +282,7 @@ void tools_command(int argc, char **argv)
 void cases_command(int argc, char **argv)
 {
     // due to PR #386, we can't just pass our own argc/argv, because we might
-    // have "nasm" as an argument -- which will trigger the selective tool rebuild.
+    // have "asm" as an argument -- which will trigger the selective tool rebuild.
     // so, we pass in an empty argument list.
     char* dummy_args[] = { "" };
     tools_command(0, dummy_args);
@@ -290,7 +290,7 @@ void cases_command(int argc, char **argv)
     RM(PATH("build", "test", "cases"));
     MKDIRS("build", "test", "cases");
 
-    if (argc == 0 || strcmp(argv[0], "nasm") != 0) {
+    if (argc == 0 || strcmp(argv[0], "asm") != 0) {
         FOREACH_FILE_IN_DIR(caze, PATH("test", "cases"), {
             if (ENDS_WITH(caze, ".basm"))
             {
@@ -388,7 +388,7 @@ void test_command(int argc, char **argv)
 {
     cases_command(argc, argv);
 
-    if (argc == 0 || strcmp(argv[0], "nasm") != 0) {
+    if (argc == 0 || strcmp(argv[0], "asm") != 0) {
         FOREACH_FILE_IN_DIR(caze, PATH("test", "cases"), {
             if (ENDS_WITH(caze, ".basm"))
             {


### PR DESCRIPTION
Was completely broken. Now builds on both amd64 and arm64 FreeBSD.
No change of #348 :

``` console
...
[INFO] CMD: ld build/test/cases/read-write.o -o build/test/cases/read-write.elf64
[INFO] CMD: build/toolchain/basm -I ./lib/ -t gas-freebsd-arm64 test/cases/rot13.basm -o build/test/cases/rot13.S
[INFO] CMD: cc -c -g build/test/cases/rot13.S -o build/test/cases/rot13.o
[INFO] CMD: ld build/test/cases/rot13.o -o build/test/cases/rot13.elf64
Assertion failed: (0 && "TODO(#348): implement some mechanism to test native executables"), function test_command, file nobuild.c, line 402.
[2] + Abort trap - core dumped    ./nobuild test asm
[nico@henricus ~/src/bm]$
```