### PR TITLE
Handle native instructions properly in code generators

### DIFF
--- a/src/library/nasm_sysv_x86_64.c
+++ b/src/library/nasm_sysv_x86_64.c
@@ -277,8 +277,11 @@ stack_push_xmm(output, "xmm1");                         \
         }
         break;
         case INST_NATIVE: {
-            if (inst.operand.as_u64 == 0) {
-                fprintf(output, "    ;; native write\n");
+            assert(inst.operand.as_u64 < basm->external_natives_size);
+            const char *const name = basm->external_natives[inst.operand.as_u64].name;
+
+            fprintf(output, "    ;; native %s\n", name);
+            if (strcmp(name, "write") == 0) {
                 switch (os_target) {
                 case OS_TARGET_LINUX:
                 case OS_TARGET_MACOS:
@@ -308,7 +311,10 @@ stack_push_xmm(output, "xmm1");                         \
                 break;
                 }
             } else {
-                assert(false && "unsupported native function");
+                fprintf(stderr, FL_Fmt": ERROR: unsupported native function `%s`\n",
+                        FL_Arg(basm->program_locations[i]),
+                        name);
+                exit(1);
             }
         }
         break;


### PR DESCRIPTION
The id of the `write` native is not fixed to 0. It depends on the order of the definition in the original BASM file. The actual native should be determined by its name.

cc @zhiayang @herrhotzenplotz @kolumb sorry that I did not catch that during the reviews. Pinging you just to let you know about this. Also, please let me know if my changes introduced any bugs