### PR TITLE
bdb : Fix startup failures

### DIFF
--- a/bdb/src/bdb.c
+++ b/bdb/src/bdb.c
@@ -38,39 +38,6 @@ Bdb_Binding *bdb_resolve_binding(Bdb_State *bdb, String_View name)
     return NULL;
 }
 
-Bdb_Err bdb_load_symtab(Bdb_State *state, const char *program_file_path)
-{
-    assert(state);
-
-    String_View symtab_file =
-        sv_from_cstr(CSTR_CONCAT(&state->sym_arena, program_file_path, ".sym"));
-
-    String_View symtab = {0};
-    if (arena_slurp_file(&state->sym_arena, symtab_file, &symtab) < 0) {
-        fprintf(stderr, "ERROR: could not read file "SV_Fmt": %s\n",
-                SV_Arg(symtab_file), strerror(errno));
-        exit(1);
-    }
-
-    while (symtab.count > 0) {
-        symtab                    = sv_trim_left(symtab);
-        String_View  raw_addr     = sv_chop_by_delim(&symtab, '\t');
-        symtab                    = sv_trim_left(symtab);
-        String_View  raw_sym_type = sv_chop_by_delim(&symtab, '\t');
-        symtab                    = sv_trim_left(symtab);
-        String_View  name         = sv_chop_by_delim(&symtab, '\n');
-        Word         value        = word_u64(sv_to_u64(raw_addr));
-        Type type                 = (Type)sv_to_u64(raw_sym_type);
-
-        state->bindings[state->bindings_size].name = name;
-        state->bindings[state->bindings_size].value = value;
-        state->bindings[state->bindings_size].type = type;
-        state->bindings_size += 1;
-    }
-
-    return BDB_OK;
-}
-
 // TODO(#187): bdb_print_instr should take information from the actual source code
 void bdb_print_instr(Bdb_State *state, FILE *f, Inst *i)
 {

--- a/bdb/src/bdb.c
+++ b/bdb/src/bdb.c
@@ -273,7 +273,7 @@ Bdb_Err bdb_reset(Bdb_State *state)
     state->is_in_step_over_mode = 0;
     state->step_over_mode_call_depth = 0;
 
-    fprintf(stdout, "TODO: BDB does not load symbols from a symbol table\n");
+    fprintf(stdout, "TODO(#467): BDB does not load symbols from a symbol table\n");
 
     // Update addresses of breakpoints on labels
     for (size_t i = 0; i < state->breakpoints_size; ++i) {

--- a/bdb/src/bdb.h
+++ b/bdb/src/bdb.h
@@ -63,7 +63,6 @@ typedef struct Bdb_State {
 } Bdb_State;
 
 Bdb_Err bdb_state_init(Bdb_State *, const char *program_file_path);
-Bdb_Err bdb_load_symtab(Bdb_State *state, const char *program_file_path);
 Bdb_Err bdb_step_instr(Bdb_State *);
 Bdb_Err bdb_step_over_instr(Bdb_State *state);
 Bdb_Err bdb_continue(Bdb_State *);


### PR DESCRIPTION
See notes in commit message.

As bdb seems a little bit broken and no issues exist/are linked for
the actual issues, I removed a couple of things that are outdated
(e.g. the symtab) and turned them into a TODO (snitch-ing required).

This makes bdb at least usable and not fail at startup, trying to find
the symbol table. Also, I stole some code from bme to load the native
write implementation, such that the virtual machine throws an error
when stepping into native write instruction.

Might fix #100 (not sure whether we can remove it)