### PR TITLE
Introduce the memory_base field in the BM file metadata

### DIFF
--- a/bang/src/bang_compiler.c
+++ b/bang/src/bang_compiler.c
@@ -683,6 +683,7 @@ void bang_prepare_var_stack(Bang *bang, Basm *basm, size_t stack_size)
     assert(sizeof(stack_start_addr) == ptr_def.size);
 
     bang->stack_frame_var_addr = basm_push_buffer_to_memory(basm, (uint8_t*) &stack_start_addr, ptr_def.size).as_u64;
+    basm->memory_base = stack_size;
 }
 
 void compile_var_def_into_basm(Bang *bang, Basm *basm, Bang_Var_Def var_def, Bang_Var_Storage storage)

--- a/basm/src/compiler.h
+++ b/basm/src/compiler.h
@@ -126,6 +126,7 @@ typedef struct {
     size_t string_lengths_size;
 
     uint8_t memory[BM_MEMORY_CAPACITY];
+    size_t memory_base;
     size_t memory_size;
     size_t memory_capacity;
 
@@ -179,6 +180,7 @@ bool basm_resolve_include_file_path(Basm *basm,
 Macrodef *basm_resolve_macrodef(Basm *basm, String_View name);
 void basm_translate_macrocall_statement(Basm *basm, Macrocall_Statement macrocall, File_Location location);
 void basm_translate_macrodef_statement(Basm *basm, Macrodef_Statement macrodef, File_Location location);
+void basm_translate_base_statement(Basm *basm, Base_Statement base_statement, File_Location location);
 void basm_translate_block_statement(Basm *basm, Block_Statement *block);
 void basm_translate_const_statement(Basm *basm, Const_Statement konst, File_Location location);
 void basm_translate_native_statement(Basm *basm, Native_Statement native, File_Location location);

--- a/basm/src/statement.h
+++ b/basm/src/statement.h
@@ -24,7 +24,8 @@ typedef enum {
     STATEMENT_KIND_FOR,
     STATEMENT_KIND_FUNCDEF,
     STATEMENT_KIND_MACROCALL,
-    STATEMENT_KIND_MACRODEF
+    STATEMENT_KIND_MACRODEF,
+    STATEMENT_KIND_BASE
 } Statement_Kind;
 
 typedef struct {
@@ -92,6 +93,10 @@ typedef struct {
     Block_Statement *body;
 } Macrodef_Statement;
 
+typedef struct {
+    uint64_t size;
+} Base_Statement;
+
 typedef union {
     Emit_Inst_Statement as_emit_inst;
     Label_Statement as_label;
@@ -108,6 +113,7 @@ typedef union {
     Fundef_Statement as_fundef;
     Macrocall_Statement as_macrocall;
     Macrodef_Statement as_macrodef;
+    Base_Statement as_base;
 } Statement_Value;
 
 struct Statement {

--- a/bm/src/bm.c
+++ b/bm/src/bm.c
@@ -891,11 +891,11 @@ void bm_load_program_from_file(Bm *bm, const char *file_path)
         exit(1);
     }
 
-    if (meta.memory_size > meta.memory_capacity) {
+    if (meta.memory_base + meta.memory_size > meta.memory_capacity) {
         fprintf(stderr,
                 "ERROR: %s: memory size %"PRIu64" is greater than declared memory capacity %"PRIu64"\n",
                 file_path,
-                meta.memory_size,
+                meta.memory_base + meta.memory_size,
                 meta.memory_capacity);
         exit(1);
     }
@@ -919,8 +919,9 @@ void bm_load_program_from_file(Bm *bm, const char *file_path)
         exit(1);
     }
 
-    n = fread(bm->memory, sizeof(bm->memory[0]), meta.memory_size, f);
+    n = fread(bm->memory + meta.memory_base, sizeof(bm->memory[0]), meta.memory_size, f);
     bm->expected_memory_size = meta.memory_size;
+    bm->memory_base = meta.memory_base;
 
     if (n != meta.memory_size) {
         fprintf(stderr, "ERROR: %s: read %zd bytes of memory section, but expected %"PRIu64" bytes.\n",

--- a/bm/src/bm.h
+++ b/bm/src/bm.h
@@ -188,6 +188,7 @@ struct Bm {
     // The program is allowed to access memory beyond the `expected_memory_size`.
     // This variable is needed for debasm to reliably recover the source code.
     size_t expected_memory_size;
+    size_t memory_base;
 
     bool halt;
 };
@@ -199,13 +200,14 @@ void bm_dump_stack(FILE *stream, const Bm *bm);
 void bm_load_program_from_file(Bm *bm, const char *file_path);
 
 #define BM_FILE_MAGIC 0xa4016d62
-#define BM_FILE_VERSION 7
+#define BM_FILE_VERSION 8
 
 PACK(struct Bm_File_Meta {
     uint32_t magic;
     uint16_t version;
     uint64_t program_size;
     uint64_t entry;
+    uint64_t memory_base;
     uint64_t memory_size;
     uint64_t memory_capacity;
     uint64_t externals_size;

--- a/debasm/src/debasm.c
+++ b/debasm/src/debasm.c
@@ -20,8 +20,9 @@ int main(int argc, char *argv[])
         printf("%%native %s\n", bm.externals[i].name);
     }
 
+    printf("%%base %zu\n", bm.memory_base);
     printf("%%const MEMORY = \"");
-    for (size_t i = 0; i < bm.expected_memory_size; ++i) {
+    for (size_t i = bm.memory_base; i < bm.expected_memory_size + bm.memory_base; ++i) {
         if (32 <= bm.memory[i] && bm.memory[i] < 127) {
             printf("%c", bm.memory[i]);
         } else {
@@ -29,7 +30,7 @@ int main(int argc, char *argv[])
         }
     }
     printf("\"\n");
-    printf("%%assert MEMORY == 0\n");
+    printf("%%assert MEMORY == %zu\n", bm.memory_base);
 
     for (Inst_Addr i = 0; i < bm.program_size; ++i) {
         if (i == bm.ip) {


### PR DESCRIPTION
This makes `bm` bytecode compiled from `bang` significantly smaller because the stack is no longer included in the file.
Furthermore, `debasm` looks way cleaner because it doesn't print the stack anymore.

The behavior of native targets remains the same.